### PR TITLE
Add reproducible web captures

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 _site/
 .git/
-assets/
+assets/*
+!assets/js/
+!assets/js/**

--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: boolean
         default: true
+      check-web-captures:
+        description: Reject stale selector-based screenshot artefacts before building.
+        required: false
+        type: boolean
+        default: true
       build-command:
         description: Optional custom command that builds the site into the output folder.
         required: false
@@ -57,7 +62,7 @@ jobs:
           bundler-cache: true
 
       - name: Setup Python
-        if: ${{ inputs.install-python-requirements || inputs.check-computations }}
+        if: ${{ inputs.install-python-requirements || inputs.check-computations || inputs.check-web-captures }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ inputs.python-version }}
@@ -78,6 +83,13 @@ jobs:
           python -c 'import yaml' 2>/dev/null || python -m pip install PyYAML==6.0.2
           core_dir="$(bundle exec ruby -e 'spec = Gem::Specification.find_by_name("unaltraweb"); print spec.full_gem_path')"
           make -C "$core_dir" manual-compute-check PROJECT="$GITHUB_WORKSPACE"
+
+      - name: Check web capture freshness
+        if: ${{ inputs.check-web-captures }}
+        run: |
+          python -c 'import yaml' 2>/dev/null || python -m pip install PyYAML==6.0.2
+          core_dir="$(bundle exec ruby -e 'spec = Gem::Specification.find_by_name("unaltraweb"); print spec.full_gem_path')"
+          make -C "$core_dir" web-capture-check PROJECT="$GITHUB_WORKSPACE"
 
       - name: Build
         env:

--- a/.github/workflows/web-capture-image.yml
+++ b/.github/workflows/web-capture-image.yml
@@ -1,0 +1,46 @@
+name: Web capture image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ghcr.io/dosquartsdedocs/unaltraweb-web-capture
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+            type=ref,event=tag
+
+      - name: Build and publish
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: scripts/web_captures/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=web-capture
+          cache-to: type=gha,mode=max,scope=web-capture

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,14 @@ COMPUTE_CPUS ?= 4
 COMPUTE_MEMORY ?= 8g
 COMPUTE_PIDS_LIMIT ?= 512
 RSTUDIO_PORT ?= 8787
+WEB_CAPTURE_SOURCE ?=
+WEB_CAPTURE_BASE_URL ?=
+WEB_CAPTURE_DOCKER_NETWORK ?=
+WEB_CAPTURE_SERVICE_HOST ?=
+WEB_CAPTURE_CONFIRM_OVERWRITE ?= 0
+WEB_CAPTURE_SCRIPT := $(CURDIR)/scripts/web_captures/render.py
+WEB_CAPTURE_IMAGE ?= ghcr.io/dosquartsdedocs/unaltraweb-web-capture:main
+WEB_CAPTURE_DOCKER_BUILD_NETWORK ?= default
 DOCKER_IMAGE ?= ghcr.io/dosquartsdedocs/unaltraweb:main
 MANUAL_PDF_IMAGE ?= unaltraweb-manual-pdf:local
 MANUAL_PDF_LANG ?=
@@ -41,8 +49,8 @@ ifneq ($(strip $(SCIMAGO_INPUT)),)
 SCIMAGO_ARGS += --input $(SCIMAGO_INPUT)
 endif
 
-.PHONY: docs-build docs-serve docs-publish docs-down metrics-scimago-fetch metrics-update metrics-update-all metrics-check manual-pdf-image manual-pdf-status manual-pdf-build manual-pdf-publish manual-compute-status manual-compute-check manual-compute-render manual-compute-image-python manual-compute-image-r manual-compute-images manual-compute-rstudio compute-base-image-python compute-base-image-r
-.PHONY: mcp-build mcp-init mcp-check mcp-smoke mcp-stdio mcp-list-tools mcp-starter-templates mcp-initialize-site mcp-site-context mcp-profile-check mcp-manual-source-quality-check mcp-manual-editorial-quality-check mcp-manual-authoring-capabilities mcp-manual-computation-status mcp-manual-computation-check mcp-manual-computation-render mcp-manual-pdf-status mcp-manual-pdf-build mcp-manual-pdf-publish mcp-profile-prune-plan mcp-profile-prune mcp-content-inventory mcp-language-policy mcp-content-approval-inventory mcp-translation-plan mcp-bibliography-inventory mcp-bibliometrics-check mcp-build-health
+.PHONY: docs-build docs-serve docs-publish docs-down metrics-scimago-fetch metrics-update metrics-update-all metrics-check manual-pdf-image manual-pdf-status manual-pdf-build manual-pdf-publish manual-compute-status manual-compute-check manual-compute-render manual-compute-image-python manual-compute-image-r manual-compute-images manual-compute-rstudio compute-base-image-python compute-base-image-r web-capture-status web-capture-check web-capture-render web-capture-image
+.PHONY: mcp-build mcp-init mcp-check mcp-smoke mcp-stdio mcp-list-tools mcp-starter-templates mcp-initialize-site mcp-site-context mcp-profile-check mcp-manual-source-quality-check mcp-manual-editorial-quality-check mcp-manual-authoring-capabilities mcp-manual-computation-status mcp-manual-computation-check mcp-manual-computation-render mcp-web-capture-status mcp-web-capture-check mcp-web-capture-render mcp-manual-pdf-status mcp-manual-pdf-build mcp-manual-pdf-publish mcp-profile-prune-plan mcp-profile-prune mcp-content-inventory mcp-language-policy mcp-content-approval-inventory mcp-translation-plan mcp-bibliography-inventory mcp-bibliometrics-check mcp-build-health
 
 mcp-build: ## Validate the lightweight Python MCP control plane
 	PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m compileall -q src/unaltraweb_mcp
@@ -60,6 +68,7 @@ mcp-smoke: mcp-check ## Run a fast deterministic MCP smoke check against PROJECT
 	PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m unaltraweb_mcp.cli --project "$(PROJECT)" mcp manual-editorial-quality-check >/dev/null
 	PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m unaltraweb_mcp.cli --project "$(PROJECT)" mcp manual-authoring-capabilities >/dev/null
 	PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m unaltraweb_mcp.cli --project "$(PROJECT)" mcp manual-computation-status >/dev/null
+	PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m unaltraweb_mcp.cli --project "$(PROJECT)" mcp web-capture-status >/dev/null
 	PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m unaltraweb_mcp.cli --project "$(PROJECT)" mcp translation-plan >/dev/null
 	PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m unaltraweb_mcp.cli --project "$(PROJECT)" mcp bibliography-inventory >/dev/null
 
@@ -98,6 +107,15 @@ mcp-manual-computation-check: ## Fail when executable manual results are stale
 
 mcp-manual-computation-render: ## Execute and publish versioned manual computation outputs
 	@PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m unaltraweb_mcp.cli --project "$(PROJECT)" mcp manual-computation-render --source "$(COMPUTE_SOURCE)" $(if $(filter 1 true TRUE yes YES y Y,$(COMPUTE_CONFIRM_OVERWRITE)),--confirm-overwrite,)
+
+mcp-web-capture-status: ## Inspect web capture recipes and generated artefacts
+	@PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m unaltraweb_mcp.cli --project "$(PROJECT)" mcp web-capture-status --source "$(WEB_CAPTURE_SOURCE)"
+
+mcp-web-capture-check: ## Fail when web capture artefacts are stale
+	@PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m unaltraweb_mcp.cli --project "$(PROJECT)" mcp web-capture-check --source "$(WEB_CAPTURE_SOURCE)"
+
+mcp-web-capture-render: ## Start an isolated preview and publish annotated SVG artefacts
+	@PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m unaltraweb_mcp.cli --project "$(PROJECT)" mcp web-capture-render --source "$(WEB_CAPTURE_SOURCE)" $(if $(filter 1 true TRUE yes YES y Y,$(WEB_CAPTURE_CONFIRM_OVERWRITE)),--confirm-overwrite,)
 
 mcp-manual-pdf-status: ## Inspect manual PDF state for PROJECT
 	@PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m unaltraweb_mcp.cli --project "$(PROJECT)" mcp manual-pdf-status --language "$(MANUAL_PDF_LANG)"
@@ -182,16 +200,28 @@ manual-compute-rstudio: manual-compute-image-r ## Open the selected R computatio
 	@image=$$(COMPUTE_PYTHON_IMAGE="$(COMPUTE_PYTHON_IMAGE)" COMPUTE_R_IMAGE="$(COMPUTE_R_IMAGE)" $(PYTHON) "$(COMPUTE_SCRIPT)" resolve --project "$(abspath $(PROJECT))" --engine r | $(PYTHON) -c 'import json,sys; print(json.load(sys.stdin)["image"])'); \
 	docker run --rm -it -p "127.0.0.1:$(RSTUDIO_PORT):8787" -e DISABLE_AUTH=true -e USERID="$(LOCAL_UID)" -e GROUPID="$(LOCAL_GID)" -v "$(abspath $(PROJECT)):/home/rstudio/project" -w /home/rstudio/project "$$image" /init
 
+web-capture-status: ## Inspect web capture recipes and generated artefacts
+	@WEB_CAPTURE_IMAGE="$(WEB_CAPTURE_IMAGE)" $(PYTHON) "$(WEB_CAPTURE_SCRIPT)" status --project "$(abspath $(PROJECT))" $(if $(strip $(WEB_CAPTURE_SOURCE)),--source "$(WEB_CAPTURE_SOURCE)",)
+
+web-capture-check: ## Fail when web capture PNG, SVG, or edited overrides are stale
+	@WEB_CAPTURE_IMAGE="$(WEB_CAPTURE_IMAGE)" $(PYTHON) "$(WEB_CAPTURE_SCRIPT)" check --project "$(abspath $(PROJECT))" $(if $(strip $(WEB_CAPTURE_SOURCE)),--source "$(WEB_CAPTURE_SOURCE)",)
+
+web-capture-render: ## Capture a trusted running preview and publish PNG plus annotated SVG
+	@WEB_CAPTURE_IMAGE="$(WEB_CAPTURE_IMAGE)" WEB_CAPTURE_DOCKER_BUILD_NETWORK="$(WEB_CAPTURE_DOCKER_BUILD_NETWORK)" WEB_CAPTURE_DOCKER_NETWORK="$(WEB_CAPTURE_DOCKER_NETWORK)" WEB_CAPTURE_SERVICE_HOST="$(WEB_CAPTURE_SERVICE_HOST)" $(PYTHON) "$(WEB_CAPTURE_SCRIPT)" render --project "$(abspath $(PROJECT))" --base-url "$(WEB_CAPTURE_BASE_URL)" $(if $(strip $(WEB_CAPTURE_SOURCE)),--source "$(WEB_CAPTURE_SOURCE)",) $(if $(filter 1 true TRUE yes YES y Y,$(WEB_CAPTURE_CONFIRM_OVERWRITE)),--confirm-overwrite,)
+
+web-capture-image: ## Build the isolated Playwright web capture image
+	docker build --network "$(WEB_CAPTURE_DOCKER_BUILD_NETWORK)" -f scripts/web_captures/Dockerfile -t "$(WEB_CAPTURE_IMAGE)" .
+
 manual-pdf-image: ## Build the isolated local Pandoc/XeLaTeX image
 	docker build -f scripts/manual/Dockerfile -t "$(MANUAL_PDF_IMAGE)" scripts/manual
 
-manual-pdf-status: manual-compute-check manual-pdf-image ## Inspect manual PDF configuration and artefacts
+manual-pdf-status: manual-compute-check web-capture-check manual-pdf-image ## Inspect manual PDF configuration and artefacts
 	docker run --rm --user "$(LOCAL_UID):$(LOCAL_GID)" -e HOME=/tmp -v "$(abspath $(PROJECT)):/project" -w /project "$(MANUAL_PDF_IMAGE)" status --project /project $(if $(strip $(MANUAL_PDF_LANG)),--language "$(MANUAL_PDF_LANG)",)
 
-manual-pdf-build: manual-compute-check manual-pdf-image ## Build manual PDFs and cover previews under tmp
+manual-pdf-build: manual-compute-check web-capture-check manual-pdf-image ## Build manual PDFs and cover previews under tmp
 	docker run --rm --user "$(LOCAL_UID):$(LOCAL_GID)" -e HOME=/tmp -v "$(abspath $(PROJECT)):/project" -w /project "$(MANUAL_PDF_IMAGE)" build --project /project $(if $(strip $(MANUAL_PDF_LANG)),--language "$(MANUAL_PDF_LANG)",)
 
-manual-pdf-publish: manual-compute-check manual-pdf-image ## Copy built PDF artefacts to configured public paths
+manual-pdf-publish: manual-compute-check web-capture-check manual-pdf-image ## Copy built PDF artefacts to configured public paths
 	docker run --rm --user "$(LOCAL_UID):$(LOCAL_GID)" -e HOME=/tmp -v "$(abspath $(PROJECT)):/project" -w /project "$(MANUAL_PDF_IMAGE)" publish --project /project $(if $(strip $(MANUAL_PDF_LANG)),--language "$(MANUAL_PDF_LANG)",) $(if $(filter 1 true TRUE yes YES y Y,$(MANUAL_PDF_PUBLISH_DRY_RUN)),--dry-run,)
 
 docs-build:

--- a/_plugins/web_capture_images.rb
+++ b/_plugins/web_capture_images.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "rexml/document"
+
+module Unaltraweb
+  module WebCaptureImages
+    module_function
+
+    BASEURL_PREFIX = /\A\{\{\s*site\.baseurl\s*\}\}/.freeze
+    REMOTE_PATH_PREFIX = %r{\A(?:[a-z]+:)?//}i.freeze
+    FENCED_CODE_BLOCK = /^[ \t]*(`{3,}|~{3,})[^\n]*\n.*?^[ \t]*\1[ \t]*$/m.freeze
+    CAPTURE_SOURCE = /\.capture\.ya?ml/i.freeze
+    ALLOWED_ELEMENTS = %w[svg g defs metadata title desc image rect path text tspan marker polygon polyline line circle ellipse clippath mask lineargradient radialgradient stop pattern use namedview grid page].freeze
+    ALLOWED_ATTRIBUTES = %w[id class version baseprofile xmlns xlink inkscape x y x1 y1 x2 y2 cx cy r rx ry width height viewbox preserveaspectratio d points transform fill stroke stroke-width stroke-linecap stroke-linejoin stroke-miterlimit stroke-dasharray stroke-dashoffset opacity fill-opacity stroke-opacity fill-rule clip-rule clip-path mask font-family font-size font-style font-weight text-anchor dominant-baseline marker-start marker-mid marker-end markerwidth markerheight refx refy orient offset stop-color stop-opacity patternunits patterncontentunits gradientunits gradienttransform spreadmethod href style data-selector groupmode label space role aria-label pagecolor bordercolor borderopacity objecttolerance gridtolerance guidetolerance showgrid showguides zoom current-layer document-units pagecheckerboard deskcolor units originx originy spacingx spacingy].freeze
+    ALLOWED_STYLE_PROPERTIES = %w[fill stroke stroke-width stroke-linecap stroke-linejoin stroke-miterlimit stroke-dasharray stroke-dashoffset opacity fill-opacity stroke-opacity fill-rule clip-rule clip-path mask font-family font-size font-style font-weight text-anchor dominant-baseline marker-start marker-mid marker-end stop-color stop-opacity display visibility].freeze
+
+    def rewrite(content, site_source:)
+      return content if content.nil? || content.empty?
+
+      rewrite_outside_code_fences(content) { |chunk| rewrite_chunk(chunk, site_source: site_source) }
+    end
+
+    def rewrite_chunk(content, site_source:)
+      out = content.dup
+      out.gsub!(/!\[([^\]]*)\]\(([^)]*?#{CAPTURE_SOURCE})(\s+"[^"]*")?\)/i) do
+        alt = Regexp.last_match(1)
+        path = svg_path_for(Regexp.last_match(2), site_source)
+        title = Regexp.last_match(3).to_s
+        "![#{alt}](#{path}#{title})"
+      end
+      out.gsub!(/(<img\b[^>]*\bsrc=)(["'])([^"']+?#{CAPTURE_SOURCE})\2/i) do
+        prefix = Regexp.last_match(1)
+        quote = Regexp.last_match(2)
+        path = svg_path_for(Regexp.last_match(3), site_source)
+        "#{prefix}#{quote}#{path}#{quote}"
+      end
+      out
+    end
+
+    def rewrite_outside_code_fences(content)
+      source = content.to_s
+      fences = []
+      protected_source = source.gsub(FENCED_CODE_BLOCK) do
+        token = "UNALTRAWEBWEBFENCEDCODEBLOCK#{fences.length}"
+        fences << Regexp.last_match(0)
+        token
+      end
+      transformed = yield(protected_source)
+      fences.each_index.reverse_each do |index|
+        transformed.gsub!("UNALTRAWEBWEBFENCEDCODEBLOCK#{index}", fences[index])
+      end
+      transformed
+    end
+
+    def svg_path_for(capture_path, site_source)
+      edited = capture_path.sub(/\.capture\.ya?ml/i, ".capture.edited.svg")
+      if local_asset_exists?(edited, site_source)
+        validate_svg!(local_asset_path(edited, site_source))
+        return edited
+      end
+
+      generated = capture_path.sub(/\.capture\.ya?ml/i, ".capture.svg")
+      local = local_asset_path(generated, site_source)
+      unless local && File.file?(local)
+        raise Jekyll::Errors::FatalException, "Missing rendered web capture SVG for #{capture_path}. Run make web-capture-render."
+      end
+      validate_svg!(local)
+      generated
+    end
+
+    def validate_svg!(path)
+      text = File.read(path, encoding: "UTF-8")
+      lowered = text.downcase
+      raise "unsafe XML declaration" if lowered.include?("<!doctype") || lowered.include?("<!entity")
+
+      document = REXML::Document.new(text)
+      document.elements.each("//*") do |element|
+        tag = element.name.to_s.downcase
+        raise "unsupported element #{tag}" unless ALLOWED_ELEMENTS.include?(tag)
+
+        element.attributes.each_attribute do |attribute|
+          name = attribute.expanded_name.to_s.split(":").last.downcase
+          value = attribute.value.to_s.strip
+          lowered_value = value.downcase
+          raise "unsupported attribute #{name}" unless ALLOWED_ATTRIBUTES.include?(name)
+          raise "unsafe attribute #{name}" if lowered_value.include?("@import") || lowered_value.include?("javascript:") || lowered_value.include?("expression(")
+          if name == "href" && !value.start_with?("data:image/png;base64,", "#")
+            raise "external SVG reference"
+          end
+          without_local_urls = lowered_value.gsub(/url\(\s*["']?#[A-Za-z_][-:.A-Za-z0-9_]*["']?\s*\)/, "")
+          if without_local_urls.include?("url(")
+            raise "external CSS reference"
+          end
+          if name == "style"
+            value.split(";").map(&:strip).reject(&:empty?).each do |declaration|
+              property, separator, = declaration.partition(":")
+              raise "unsupported style #{property.strip}" if separator.empty? || !ALLOWED_STYLE_PROPERTIES.include?(property.strip.downcase)
+            end
+          end
+        end
+      end
+    rescue REXML::ParseException, RuntimeError => e
+      raise Jekyll::Errors::FatalException, "Unsafe web capture SVG #{path}: #{e.message}"
+    end
+
+    def local_asset_exists?(asset_path, site_source)
+      local = local_asset_path(asset_path, site_source)
+      local && File.file?(local)
+    end
+
+    def local_asset_path(asset_path, site_source)
+      local_path = asset_path
+        .sub(BASEURL_PREFIX, "")
+        .split(/[?#]/, 2)
+        .first.to_s
+        .sub(%r{\A/+}, "")
+      return nil if local_path.empty? || local_path.match?(REMOTE_PATH_PREFIX)
+
+      root = File.expand_path(site_source)
+      path = File.expand_path(local_path, root)
+      return nil unless path == root || path.start_with?("#{root}/")
+
+      path
+    end
+
+    Jekyll::Hooks.register :site, :post_read do |site|
+      site.static_files.reject! do |file|
+        relative = file.relative_path.to_s.downcase
+        if relative.end_with?(".capture.svg")
+          source = file.path.sub(/\.capture\.svg\z/i, ".capture.yml")
+          source_yaml = file.path.sub(/\.capture\.svg\z/i, ".capture.yaml")
+          edited = file.path.sub(/\.capture\.svg\z/i, ".capture.edited.svg")
+          remove = (!File.file?(source) && !File.file?(source_yaml)) || File.file?(edited)
+          validate_svg!(file.path) unless remove
+          remove
+        elsif relative.end_with?(".capture.edited.svg")
+          source = file.path.sub(/\.capture\.edited\.svg\z/i, ".capture.yml")
+          source_yaml = file.path.sub(/\.capture\.edited\.svg\z/i, ".capture.yaml")
+          remove = !File.file?(source) && !File.file?(source_yaml)
+          validate_svg!(file.path) unless remove
+          remove
+        else
+          relative.end_with?(".capture.yml", ".capture.yaml", ".capture.png")
+        end
+      end
+    end
+  end
+end
+
+Jekyll::Hooks.register [:documents, :pages], :pre_render do |doc|
+  next unless doc.respond_to?(:content) && doc.content
+
+  doc.content = Unaltraweb::WebCaptureImages.rewrite(doc.content, site_source: doc.site.source)
+end if defined?(Jekyll::Hooks)

--- a/docs/_documentation/en/02-tools.md
+++ b/docs/_documentation/en/02-tools.md
@@ -45,6 +45,9 @@ make build
 make publish
 make test
 make screenshots
+make web-capture-status
+make web-capture-render WEB_CAPTURE_SOURCE=assets/captures/chapter.capture.yml
+make web-capture-check
 make metrics-update
 make cv-preview CV_PDF=assets/pdf/cv.pdf CV_PREVIEW=assets/img/cv-preview.jpg
 make down

--- a/docs/_documentation/en/20-syntax.md
+++ b/docs/_documentation/en/20-syntax.md
@@ -155,6 +155,35 @@ When `*.edited.svg` exists, the build keeps using it and does not overwrite it.
 Agents changing the diagram source should ask whether to keep the edited SVG or
 replace it with a regenerated version.
 
+## Selector-Based Web Captures
+
+Store a web capture recipe under `assets/` and reference the recipe as the image source:
+
+```markdown
+![Chapter navigation](assets/captures/chapter.capture.yml "Annotated chapter navigation")
+```
+
+The recipe uses a local preview path and CSS selectors rather than arbitrary browser scripts:
+
+```yaml
+version: 1
+path: /manual/en/chapter/
+viewport: {width: 1440, height: 900}
+theme:
+  setting: cafe
+waits:
+  selectors: [.manual-layout]
+inputs:
+  - _chapters/en/chapter.md
+annotations:
+  - id: chapter-navigation
+    selector: .manual-sidebar
+    kind: arrow
+    text: Chapter navigation
+```
+
+`make web-capture-render` keeps the untouched `*.capture.png` and generates a self-contained `*.capture.svg` with editable vector layers. A manually reviewed `*.capture.edited.svg` wins over the generated SVG and is never overwritten. Commit the recipe, PNG, SVG, and `.unaltraweb/web-captures.lock.json` together. `web-capture-check` blocks stale output and stale edited overrides. Ordinary Jekyll and PDF builds consume only the selected SVG and do not run Chromium.
+
 ## Code Fences
 
 Use language names for syntax highlighting. Common teaching languages are supported through Rouge:

--- a/docs/_documentation/en/42-docker-image.md
+++ b/docs/_documentation/en/42-docker-image.md
@@ -132,3 +132,15 @@ Core maintainers publish both base images with the manual `Compute images` workf
 Projects can call `.github/workflows/project-compute-image.yml` to publish their own extension package. Use a separate package name such as `example-compute-r`; do not encode project dependencies as variants of `unaltraweb-compute-r`.
 
 The current publication workflows build `linux/amd64` images. ARM authors need Docker emulation or a separately published compatible image; image IDs recorded in the computation lock are platform-specific.
+
+## Web Capture Image
+
+Selector-based screenshot authoring uses a separate Playwright image rather than adding Chromium to the Jekyll runtime:
+
+```text
+ghcr.io/dosquartsdedocs/unaltraweb-web-capture
+```
+
+The image contains pinned Playwright/Chromium, the capture worker, the Python status controller, and the core visual sources used in fingerprints. `make web-capture-image` builds the local image; the manual `Web capture image` workflow publishes default-branch, commit, and release tags to GHCR.
+
+Rendering creates an ephemeral Docker `--internal` network shared only by Jekyll and Chromium, keeps browser requests on the preview origin, blocks service workers, popups, and WebSockets, drops Linux capabilities, uses a read-only container root and bounded resources, and writes only the declared PNG/SVG outputs under the mounted project. Ordinary checks run without browser execution or network access.

--- a/docs/agents/manual-authoring-components.md
+++ b/docs/agents/manual-authoring-components.md
@@ -115,6 +115,19 @@ Store reusable sources under `assets/diagrams/` and reference them as captioned 
 
 Use Mermaid `.mmd` for flows and PlantUML `.puml` or `.plantuml` for structured diagrams. Prefer PlantUML `@startfiles` for file trees. `diavisuals` generates the SVG; preserve an existing `*.edited.svg` unless the author explicitly approves replacement. Do not use inline Mermaid or PlantUML fences in manuals.
 
+## Web captures
+
+Use a versioned `.capture.yml` recipe when a teaching figure must show a rendered website. The recipe stores a local preview path, viewport, theme, waits, declared inputs, and CSS selectors for annotations. Rendering creates:
+
+```text
+page.capture.yml
+page.capture.png
+page.capture.svg
+page.capture.edited.svg  # optional author-owned override
+```
+
+Reference `page.capture.yml` as the captioned image source. Jekyll and the PDF builder prefer `page.capture.edited.svg` when it exists, otherwise `page.capture.svg`. The PNG is the untouched browser capture; annotations remain editable vector layers in the self-contained SVG. Never overwrite an edited SVG without approval, and do not publish while `web_capture_check` reports it stale.
+
 ## Citations, code, and math
 
 Use verified bibliography keys:

--- a/docs/agents/mcp-contract.md
+++ b/docs/agents/mcp-contract.md
@@ -28,6 +28,7 @@ The opened workspace is the consumer website repository. Factory logic remains i
 | `web://prompts` | Reusable website workflow prompts. |
 | `web://manual-writing-guidance` | Generic drafting and style-review prompts combined with the site's `context/writing-profile.md` when available. |
 | `web://manual-authoring-components` | Supported prose structures and component syntax, including callouts, definition lists, figure layouts, tables, diagrams, citations, and web/PDF compatibility. |
+| `web://web-captures` | Selector-based screenshot recipes, original PNGs, editable SVG layers, edited overrides, and freshness. |
 
 ## Tools
 
@@ -41,6 +42,9 @@ The opened workspace is the consumer website repository. Factory logic remains i
 | `manual_source_quality_check` | For `unaltremanual`, check captioned table blocks, captioned figures, and external Mermaid/PlantUML diagram sources. |
 | `manual_editorial_quality_check` | Reject non-publishable metatext, user/agent instructions, workflow markers, drafting notes, and placeholders in manual bodies; return the editorial review checklist and local writing-profile path. |
 | `manual_authoring_capabilities` | Return the paragraph-development model and structured component catalogue an MCP writing assistant must use. |
+| `web_capture_status` | Inspect `.capture.yml` recipes, PNG/SVG artefacts, edited overrides, and freshness without starting Chromium. |
+| `web_capture_check` | Reject missing, modified, stale, orphaned, or obsolete edited capture artefacts. |
+| `web_capture_render` | Start Jekyll and Chromium on an ephemeral internal Docker network, then publish original PNG plus editable annotated SVG from declared CSS selectors. |
 | `manual_pdf_status` | Inspect PDF configuration, sources, generated artefacts, published paths, and freshness without writing files. |
 | `manual_pdf_build` | Build one or all configured language PDFs and first-page cover previews under `tmp/`. |
 | `manual_pdf_publish` | Copy built PDFs and covers to configured public assets. Defaults to dry-run; real publication requires explicit confirmation. |

--- a/lib/unaltraweb.rb
+++ b/lib/unaltraweb.rb
@@ -17,6 +17,7 @@ require_relative "unaltraweb/version"
   remove-accents
   search-data
   theme-cache-bust
+  web_capture_images
 ].each do |plugin|
   require File.expand_path("../_plugins/#{plugin}", __dir__)
 end

--- a/mcp-factory.yml
+++ b/mcp-factory.yml
@@ -2,7 +2,7 @@
 name: unaltraweb
 kind: codex-mcp-factory
 version: 0.1.0
-description: Reusable Jekyll website factory with MCP tooling for content, profiles, bibliography, bibliometrics, and build checks.
+description: Reusable Jekyll website factory with MCP tooling for content, profiles, captures, bibliography, bibliometrics, and build checks.
 install_scope: user
 workspace_rule:
   consumer_root: .
@@ -37,6 +37,7 @@ workspace_rule:
     - tmp
     - .cache/scimago
     - assets/diagrams/**/*.svg from Mermaid or PlantUML sources
+    - assets/**/*.capture.png and assets/**/*.capture.svg from selector-based web capture recipes
   allowed_external_writes: []
 runtime:
   kind: python
@@ -83,6 +84,7 @@ mcp:
     - web://manual-writing-guidance
     - web://manual-authoring-components
     - web://manual-computations
+    - web://web-captures
     - web://profile-prune-plan
     - web://content-inventory
     - web://bibliography
@@ -101,6 +103,9 @@ mcp:
     - manual_computation_status
     - manual_computation_check
     - manual_computation_render
+    - web_capture_status
+    - web_capture_check
+    - web_capture_render
     - manual_pdf_status
     - manual_pdf_build
     - manual_pdf_publish

--- a/scripts/manual/build_pdf.py
+++ b/scripts/manual/build_pdf.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +33,28 @@ IMAGE_RE = re.compile(r"!\[([^\]]*)\]\((\S+?)(?:\s+[\"']([^\"']+)[\"'])?\)")
 TABLE_DIV_RE = re.compile(r'^::: table\s+["\'](.+?)["\']\s*\n(.*?)^:::\s*$', re.MULTILINE | re.DOTALL)
 LANGUAGE_NAMES = {"ca": "catalan", "es": "spanish", "en": "english"}
 LANGUAGE_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*\Z")
+CAPTURE_SVG_ALLOWED_ELEMENTS = {
+    "svg", "g", "defs", "metadata", "title", "desc", "image", "rect", "path", "text", "tspan",
+    "marker", "polygon", "polyline", "line", "circle", "ellipse", "clippath", "mask", "lineargradient",
+    "radialgradient", "stop", "pattern", "use", "namedview", "grid", "page",
+}
+CAPTURE_SVG_ALLOWED_ATTRIBUTES = {
+    "id", "class", "version", "baseprofile", "x", "y", "x1", "y1", "x2", "y2", "cx", "cy", "r", "rx", "ry",
+    "width", "height", "viewbox", "preserveaspectratio", "d", "points", "transform", "fill", "stroke", "stroke-width",
+    "stroke-linecap", "stroke-linejoin", "stroke-miterlimit", "stroke-dasharray", "stroke-dashoffset", "opacity", "fill-opacity",
+    "stroke-opacity", "fill-rule", "clip-rule", "clip-path", "mask", "font-family", "font-size", "font-style", "font-weight",
+    "text-anchor", "dominant-baseline", "marker-start", "marker-mid", "marker-end", "markerwidth", "markerheight", "refx", "refy",
+    "orient", "offset", "stop-color", "stop-opacity", "patternunits", "patterncontentunits", "gradientunits", "gradienttransform",
+    "spreadmethod", "href", "style", "data-selector", "groupmode", "label", "space", "role", "aria-label", "pagecolor",
+    "bordercolor", "borderopacity", "objecttolerance", "gridtolerance", "guidetolerance", "showgrid", "showguides", "zoom",
+    "current-layer", "document-units", "pagecheckerboard", "deskcolor", "units", "originx", "originy", "spacingx", "spacingy",
+}
+CAPTURE_SVG_ALLOWED_STYLE_PROPERTIES = {
+    "fill", "stroke", "stroke-width", "stroke-linecap", "stroke-linejoin", "stroke-miterlimit", "stroke-dasharray",
+    "stroke-dashoffset", "opacity", "fill-opacity", "stroke-opacity", "fill-rule", "clip-rule", "clip-path", "mask",
+    "font-family", "font-size", "font-style", "font-weight", "text-anchor", "dominant-baseline", "marker-start", "marker-mid",
+    "marker-end", "stop-color", "stop-opacity", "display", "visibility",
+}
 METADATA_LABELS = {
     "ca": {
         "title": "Fitxa del manual",
@@ -228,8 +251,51 @@ def manual_sources(project: Path, config: dict[str, Any], lang: str) -> tuple[Pa
     return home, numbered + references, lang
 
 
-def resolve_diagram(project: Path, raw_path: str) -> str:
+def validate_capture_svg(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    lowered = text.lower()
+    if "<!doctype" in lowered or "<!entity" in lowered:
+        raise ManualPdfError(f"Unsafe web capture SVG: {path}")
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError as exc:
+        raise ManualPdfError(f"Invalid web capture SVG: {path}: {exc}") from exc
+    for element in root.iter():
+        tag = element.tag.rsplit("}", 1)[-1].lower()
+        if tag not in CAPTURE_SVG_ALLOWED_ELEMENTS:
+            raise ManualPdfError(f"Unsupported web capture SVG element in {path}: {tag}")
+        for raw_name, raw_value in element.attrib.items():
+            name = raw_name.rsplit("}", 1)[-1].lower()
+            value = raw_value.strip()
+            lowered_value = value.lower()
+            if name not in CAPTURE_SVG_ALLOWED_ATTRIBUTES:
+                raise ManualPdfError(f"Unsupported web capture SVG attribute in {path}: {name}")
+            if "@import" in lowered_value or "javascript:" in lowered_value or "expression(" in lowered_value:
+                raise ManualPdfError(f"Unsafe web capture SVG attribute in {path}: {name}")
+            if name == "href" and not (value.startswith("data:image/png;base64,") or value.startswith("#")):
+                raise ManualPdfError(f"External web capture SVG reference in {path}")
+            without_local_urls = re.sub(r"url\(\s*['\"]?#[A-Za-z_][-:.A-Za-z0-9_]*['\"]?\s*\)", "", lowered_value)
+            if "url(" in without_local_urls:
+                raise ManualPdfError(f"External CSS reference in web capture SVG: {path}")
+            if name == "style":
+                declarations = [part.strip() for part in value.split(";") if part.strip()]
+                for declaration in declarations:
+                    property_name, separator, _ = declaration.partition(":")
+                    if not separator or property_name.strip().lower() not in CAPTURE_SVG_ALLOWED_STYLE_PROPERTIES:
+                        raise ManualPdfError(f"Unsupported CSS property in web capture SVG {path}: {property_name.strip()}")
+
+
+def resolve_visual_source(project: Path, raw_path: str) -> str:
     path = raw_path.lstrip("/")
+    if path.lower().endswith((".capture.yml", ".capture.yaml")):
+        source = safe_relative(project, path, label="web capture source", must_exist=True)
+        base = str(source).rsplit(".", 1)[0]
+        candidates = [Path(base + ".edited.svg"), Path(base + ".svg")]
+        for candidate in candidates:
+            if candidate.is_file():
+                validate_capture_svg(candidate)
+                return str(candidate.relative_to(project))
+        raise ManualPdfError(f"No printable SVG found for web capture source: {path}")
     if not path.lower().endswith((".mmd", ".puml", ".plantuml")):
         return path
     source = safe_relative(project, path, label="diagram source", must_exist=True)
@@ -253,7 +319,7 @@ def transform_markdown(project: Path, text: str, source: Path) -> str:
 
     def image(match: re.Match[str]) -> str:
         alt, raw_path, title = match.groups()
-        printable = resolve_diagram(project, raw_path)
+        printable = resolve_visual_source(project, raw_path)
         caption = title or alt
         return f"![{caption}]({printable})"
 

--- a/scripts/web_captures/Dockerfile
+++ b/scripts/web_captures/Dockerfile
@@ -1,0 +1,31 @@
+FROM mcr.microsoft.com/playwright@sha256:f1e7e01021efd65dd1a2c56064be399f3e4de00fd021ac561325f2bfbb2b837a
+
+RUN rm -f /etc/apt/sources.list.d/nodesource.list \
+    && for sources in /etc/apt/sources.list /etc/apt/sources.list.d/*.sources; do \
+      if test -f "$sources"; then \
+        sed -i \
+          -e 's|http://archive.ubuntu.com|https://archive.ubuntu.com|g' \
+          -e 's|http://security.ubuntu.com|https://security.ubuntu.com|g' \
+          "$sources"; \
+      fi; \
+    done \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y python3 python3-yaml \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/unaltraweb/scripts/web_captures
+
+COPY scripts/web_captures/package.json scripts/web_captures/package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY scripts/web_captures/capture.mjs ./capture.mjs
+COPY scripts/web_captures/render.py ./render.py
+COPY scripts/web_captures/Dockerfile ./Dockerfile
+COPY _config.yml /opt/unaltraweb/_config.yml
+COPY _plugins /opt/unaltraweb/_plugins
+COPY _layouts /opt/unaltraweb/_layouts
+COPY _includes /opt/unaltraweb/_includes
+COPY _sass /opt/unaltraweb/_sass
+COPY assets/js /opt/unaltraweb/assets/js
+
+ENTRYPOINT ["node", "/opt/unaltraweb/scripts/web_captures/capture.mjs"]

--- a/scripts/web_captures/capture.mjs
+++ b/scripts/web_captures/capture.mjs
@@ -1,0 +1,157 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { chromium } from "playwright";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function sameOrigin(candidate, origin) {
+  try {
+    const url = new URL(candidate);
+    return url.protocol === "data:" || url.protocol === "blob:" || url.origin === origin;
+  } catch {
+    return false;
+  }
+}
+
+async function selectorBox(page, item, label) {
+  const selector = item.selector;
+  const count = await page.locator(selector).count();
+  const strict = item.strict !== false;
+  const required = item.required !== false;
+  if (!count) {
+    if (required) fail(`Missing ${label} selector: ${selector}`);
+    return null;
+  }
+  if (strict && count !== 1) fail(`${label} selector must match exactly one element: ${selector}`);
+  const index = strict ? 0 : Number(item.nth || 0);
+  if (index < 0 || index >= count) fail(`${label} selector index is out of range: ${selector}`);
+  const locator = page.locator(selector).nth(index);
+  return locator.evaluate((element) => {
+    const box = element.getBoundingClientRect();
+    return {
+      x: box.x + window.scrollX,
+      y: box.y + window.scrollY,
+      width: box.width,
+      height: box.height,
+    };
+  });
+}
+
+async function waitForImages(page) {
+  await page.waitForFunction(() => Array.from(document.images).every((image) => image.complete && (!image.currentSrc || image.naturalWidth > 0)));
+}
+
+async function main() {
+  const configPath = process.argv[2];
+  if (!configPath) fail("Usage: capture.mjs CONFIG.json");
+  const config = JSON.parse(await readFile(configPath, "utf8"));
+  const target = new URL(config.url);
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const context = await browser.newContext({
+      viewport: { width: config.viewport.width, height: config.viewport.height },
+      deviceScaleFactor: config.viewport.device_scale_factor,
+      colorScheme: config.theme.color_scheme,
+      reducedMotion: "reduce",
+      locale: config.locale || "en-US",
+      serviceWorkers: "block",
+    });
+    if (config.theme.setting) {
+      await context.addInitScript((setting) => localStorage.setItem("theme", setting), config.theme.setting);
+    }
+    await context.route("**/*", async (route) => {
+      if (sameOrigin(route.request().url(), target.origin)) await route.continue();
+      else await route.abort("blockedbyclient");
+    });
+    await context.routeWebSocket("**/*", (route) => route.close());
+    const page = await context.newPage();
+    context.on("page", (candidate) => {
+      if (candidate !== page) candidate.close().catch(() => {});
+    });
+    const response = await page.goto(target.href, {
+      waitUntil: config.waits.wait_until,
+      timeout: config.waits.timeout_ms,
+    });
+    if (!response) fail(`Navigation returned no response: ${target.href}`);
+    if (response.status() < 200 || response.status() >= 400) fail(`Navigation failed with HTTP ${response.status()}: ${target.href}`);
+    const finalUrl = new URL(page.url());
+    if (finalUrl.origin !== target.origin) fail(`Navigation left the allowed origin: ${finalUrl.href}`);
+
+    for (const wait of config.waits.selectors) {
+      await page.locator(wait.selector).waitFor({ state: wait.state, timeout: config.waits.timeout_ms });
+    }
+    if (config.waits.fonts) await page.evaluate(() => document.fonts.ready);
+    if (config.waits.images) await waitForImages(page);
+    if (config.waits.delay_ms) await page.waitForTimeout(config.waits.delay_ms);
+
+    if (config.theme.expect) {
+      const expected = config.theme.expect;
+      const actual = await page.locator(expected.selector).first().getAttribute(expected.attribute);
+      if (actual !== expected.equals) fail(`Theme expectation failed for ${expected.selector}[${expected.attribute}]: expected ${expected.equals}, got ${actual}`);
+    }
+
+    let origin = { x: 0, y: 0 };
+    let fullPage = config.capture.full_page === true;
+    let clip;
+    const captureSelector = config.capture.selector || config.capture.clip?.selector;
+    if (captureSelector) {
+      const item = { selector: captureSelector, strict: true, required: true };
+      const box = await selectorBox(page, item, "capture");
+      const padding = Number(config.capture.clip ? config.capture.clip.padding : config.capture.padding);
+      clip = {
+        x: Math.max(0, box.x - padding),
+        y: Math.max(0, box.y - padding),
+        width: box.width + padding * 2,
+        height: box.height + padding * 2,
+      };
+      origin = { x: clip.x, y: clip.y };
+      fullPage = false;
+    }
+
+    const annotations = [];
+    for (const annotation of config.annotations) {
+      const box = await selectorBox(page, annotation, `annotation ${annotation.id}`);
+      if (box) annotations.push({ ...annotation, box });
+    }
+
+    const cssDimensions = fullPage
+      ? await page.evaluate(() => ({ width: document.documentElement.scrollWidth, height: document.documentElement.scrollHeight }))
+      : clip
+        ? { width: clip.width, height: clip.height }
+        : { width: config.viewport.width, height: config.viewport.height };
+    const pixelWidth = Math.ceil(cssDimensions.width * config.viewport.device_scale_factor);
+    const pixelHeight = Math.ceil(cssDimensions.height * config.viewport.device_scale_factor);
+    if (pixelWidth > 20000 || pixelHeight > 20000 || pixelWidth * pixelHeight > 80000000) {
+      fail(`Capture dimensions exceed safety limits: ${pixelWidth}x${pixelHeight}`);
+    }
+
+    await page.screenshot({
+      path: config.png_path,
+      fullPage,
+      clip,
+      animations: "disabled",
+      caret: "hide",
+      scale: "device",
+    });
+    const result = {
+      ok: true,
+      browser_version: browser.version(),
+      final_url: finalUrl.href,
+      status: response.status(),
+      origin,
+      dimensions: cssDimensions,
+      device_scale_factor: config.viewport.device_scale_factor,
+      annotations,
+    };
+    await writeFile(config.result_path, JSON.stringify(result, null, 2) + "\n", "utf8");
+    process.stdout.write(JSON.stringify(result) + "\n");
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.stack || error.message}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/web_captures/package-lock.json
+++ b/scripts/web_captures/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "unaltraweb-web-captures",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "unaltraweb-web-captures",
+      "version": "0.1.0",
+      "dependencies": {
+        "playwright": "1.56.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dependencies": {
+        "playwright-core": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/scripts/web_captures/package.json
+++ b/scripts/web_captures/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "unaltraweb-web-captures",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "playwright": "1.56.1"
+  }
+}

--- a/scripts/web_captures/render.py
+++ b/scripts/web_captures/render.py
@@ -1,0 +1,846 @@
+#!/usr/bin/env python3
+"""Capture local web previews as versioned PNG and annotated SVG artefacts."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import contextlib
+import datetime as dt
+import fcntl
+import hashlib
+import html
+import json
+import os
+import re
+import secrets
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - supplied by project tooling
+    raise SystemExit("PyYAML is required for unaltraweb web captures.") from exc
+
+
+LOCK_PATH = Path(".unaltraweb/web-captures.lock.json")
+SOURCE_SUFFIX = ".capture.yml"
+DEFAULT_IMAGE = "ghcr.io/dosquartsdedocs/unaltraweb-web-capture:main"
+DEFAULT_VIEWPORT = {"width": 1440, "height": 900, "device_scale_factor": 1}
+CAPTURE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,79}$")
+SAFE_SOURCE_RE = re.compile(r"^[A-Za-z0-9_./-]+\.capture\.yml$")
+SVG_METADATA_RE = re.compile(r'<metadata\s+id="unaltraweb-capture">(.*?)</metadata>', re.DOTALL)
+SVG_ALLOWED_ELEMENTS = {
+    "svg", "g", "defs", "metadata", "title", "desc", "image", "rect", "path", "text", "tspan",
+    "marker", "polygon", "polyline", "line", "circle", "ellipse", "clippath", "mask", "lineargradient",
+    "radialgradient", "stop", "pattern", "use", "namedview", "grid", "page",
+}
+SVG_ALLOWED_ATTRIBUTES = {
+    "id", "class", "version", "baseprofile", "x", "y", "x1", "y1", "x2", "y2", "cx", "cy", "r", "rx", "ry",
+    "width", "height", "viewbox", "preserveaspectratio", "d", "points", "transform", "fill", "stroke", "stroke-width",
+    "stroke-linecap", "stroke-linejoin", "stroke-miterlimit", "stroke-dasharray", "stroke-dashoffset", "opacity", "fill-opacity",
+    "stroke-opacity", "fill-rule", "clip-rule", "clip-path", "mask", "font-family", "font-size", "font-style", "font-weight",
+    "text-anchor", "dominant-baseline", "marker-start", "marker-mid", "marker-end", "markerwidth", "markerheight", "refx", "refy",
+    "orient", "offset", "stop-color", "stop-opacity", "patternunits", "patterncontentunits", "gradientunits", "gradienttransform",
+    "spreadmethod", "href", "style", "data-selector", "groupmode", "label", "space", "role", "aria-label", "pagecolor",
+    "bordercolor", "borderopacity", "objecttolerance", "gridtolerance", "guidetolerance", "showgrid", "showguides", "zoom",
+    "current-layer", "document-units", "pagecheckerboard", "deskcolor", "units", "originx", "originy", "spacingx", "spacingy",
+}
+SVG_ALLOWED_STYLE_PROPERTIES = {
+    "fill", "stroke", "stroke-width", "stroke-linecap", "stroke-linejoin", "stroke-miterlimit", "stroke-dasharray",
+    "stroke-dashoffset", "opacity", "fill-opacity", "stroke-opacity", "fill-rule", "clip-rule", "clip-path", "mask",
+    "font-family", "font-size", "font-style", "font-weight", "text-anchor", "dominant-baseline", "marker-start", "marker-mid",
+    "marker-end", "stop-color", "stop-opacity", "display", "visibility",
+}
+
+
+class WebCaptureError(RuntimeError):
+    pass
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+
+
+def json_dump(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def file_signature(path: Path) -> dict[str, Any]:
+    data = path.read_bytes()
+    return {"sha256": sha256_bytes(data), "size": len(data)}
+
+
+def path_signatures(project: Path, path: Path) -> list[dict[str, str]]:
+    files = [path] if path.is_file() else sorted(item for item in path.rglob("*") if item.is_file())
+    return [{"path": relative(project, item), "sha256": file_signature(item)["sha256"]} for item in files]
+
+
+def safe_relative(project: Path, raw: str, *, label: str, must_exist: bool = False) -> Path:
+    value = str(raw or "").strip()
+    if not value:
+        raise WebCaptureError(f"No {label} path is configured.")
+    relative = Path(value)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise WebCaptureError(f"{label} must be a project-relative path: {raw}")
+    resolved = (project / relative).resolve()
+    try:
+        resolved.relative_to(project)
+    except ValueError as exc:
+        raise WebCaptureError(f"{label} escapes the project: {raw}") from exc
+    if must_exist and not resolved.exists():
+        raise WebCaptureError(f"Missing {label}: {relative}")
+    return resolved
+
+
+def relative(project: Path, path: Path) -> str:
+    return str(path.resolve().relative_to(project)).replace(os.sep, "/")
+
+
+def validate_keys(mapping: dict[str, Any], allowed: set[str], *, label: str) -> None:
+    unknown = sorted(str(key) for key in mapping if key not in allowed)
+    if unknown:
+        raise WebCaptureError(f"Unknown {label} keys: {', '.join(unknown)}")
+
+
+def mapping(value: Any, *, label: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise WebCaptureError(f"{label} must be a mapping.")
+    return value
+
+
+def bounded_int(value: Any, *, label: str, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
+        raise WebCaptureError(f"{label} must be an integer between {minimum} and {maximum}.")
+    return value
+
+
+def validate_selector(value: Any, *, label: str) -> str:
+    selector = str(value or "").strip()
+    if not selector or len(selector) > 500 or any(character in selector for character in "\r\n\0"):
+        raise WebCaptureError(f"{label} must be a non-empty CSS selector of at most 500 characters.")
+    return selector
+
+
+def validate_path(value: Any) -> str:
+    path = str(value or "").strip()
+    parsed = urlsplit(path)
+    if not path.startswith("/") or path.startswith("//") or parsed.scheme or parsed.netloc or parsed.fragment or any(ord(char) < 32 for char in path):
+        raise WebCaptureError("Capture path must be a local absolute URL path without a scheme, host, fragment, or control characters.")
+    return path
+
+
+def normalize_viewport(raw: Any) -> dict[str, Any]:
+    viewport = {**DEFAULT_VIEWPORT, **mapping(raw, label="viewport")}
+    validate_keys(viewport, {"width", "height", "device_scale_factor"}, label="viewport")
+    width = bounded_int(viewport["width"], label="viewport width", minimum=320, maximum=4096)
+    height = bounded_int(viewport["height"], label="viewport height", minimum=240, maximum=4096)
+    scale = viewport["device_scale_factor"]
+    if scale not in {1, 2}:
+        raise WebCaptureError("viewport device_scale_factor must be 1 or 2.")
+    return {"width": width, "height": height, "device_scale_factor": scale}
+
+
+def normalize_capture(raw: Any) -> dict[str, Any]:
+    capture = mapping(raw, label="capture")
+    validate_keys(capture, {"full_page", "selector", "clip", "padding"}, label="capture")
+    result: dict[str, Any] = {"full_page": bool(capture.get("full_page", False))}
+    if capture.get("selector"):
+        result["selector"] = validate_selector(capture["selector"], label="capture selector")
+    if capture.get("clip"):
+        clip = mapping(capture["clip"], label="capture clip")
+        validate_keys(clip, {"selector", "padding"}, label="capture clip")
+        result["clip"] = {
+            "selector": validate_selector(clip.get("selector"), label="capture clip selector"),
+            "padding": bounded_int(clip.get("padding", 0), label="capture clip padding", minimum=0, maximum=500),
+        }
+    result["padding"] = bounded_int(capture.get("padding", 0), label="capture padding", minimum=0, maximum=500)
+    modes = int(result["full_page"]) + int("selector" in result) + int("clip" in result)
+    if modes > 1:
+        raise WebCaptureError("capture full_page, selector, and clip are mutually exclusive.")
+    return result
+
+
+def normalize_theme(raw: Any) -> dict[str, Any]:
+    theme = mapping(raw, label="theme")
+    validate_keys(theme, {"setting", "color_scheme", "expect"}, label="theme")
+    setting = str(theme.get("setting") or "").strip()
+    if len(setting) > 80 or any(ord(char) < 32 for char in setting):
+        raise WebCaptureError("theme setting is invalid.")
+    color_scheme = str(theme.get("color_scheme") or ("dark" if setting == "dark" else "light"))
+    if color_scheme not in {"light", "dark", "no-preference"}:
+        raise WebCaptureError("theme color_scheme must be light, dark, or no-preference.")
+    result: dict[str, Any] = {"setting": setting, "color_scheme": color_scheme, "expect": None}
+    if theme.get("expect"):
+        expect = mapping(theme["expect"], label="theme expect")
+        validate_keys(expect, {"selector", "attribute", "equals"}, label="theme expect")
+        attribute = str(expect.get("attribute") or "").strip()
+        equals = str(expect.get("equals") or "")
+        if not re.fullmatch(r"[A-Za-z_:][-A-Za-z0-9_:.]*", attribute):
+            raise WebCaptureError("theme expect attribute is invalid.")
+        result["expect"] = {
+            "selector": validate_selector(expect.get("selector"), label="theme expect selector"),
+            "attribute": attribute,
+            "equals": equals,
+        }
+    return result
+
+
+def normalize_waits(raw: Any) -> dict[str, Any]:
+    waits = mapping(raw, label="waits")
+    validate_keys(waits, {"wait_until", "timeout_ms", "delay_ms", "fonts", "images", "selectors"}, label="waits")
+    wait_until = str(waits.get("wait_until") or "load")
+    if wait_until not in {"load", "domcontentloaded", "commit"}:
+        raise WebCaptureError("waits wait_until must be load, domcontentloaded, or commit.")
+    selectors = []
+    for index, raw_selector in enumerate(waits.get("selectors") or []):
+        item = {"selector": raw_selector} if isinstance(raw_selector, str) else mapping(raw_selector, label=f"wait selector {index}")
+        validate_keys(item, {"selector", "state"}, label=f"wait selector {index}")
+        state = str(item.get("state") or "visible")
+        if state not in {"attached", "detached", "visible", "hidden"}:
+            raise WebCaptureError(f"Invalid wait selector state: {state}")
+        selectors.append({"selector": validate_selector(item.get("selector"), label=f"wait selector {index}"), "state": state})
+    if len(selectors) > 100:
+        raise WebCaptureError("At most 100 wait selectors are allowed.")
+    return {
+        "wait_until": wait_until,
+        "timeout_ms": bounded_int(waits.get("timeout_ms", 30000), label="wait timeout", minimum=1000, maximum=120000),
+        "delay_ms": bounded_int(waits.get("delay_ms", 0), label="wait delay", minimum=0, maximum=10000),
+        "fonts": waits.get("fonts", True) is not False,
+        "images": waits.get("images", True) is not False,
+        "selectors": selectors,
+    }
+
+
+def normalize_annotations(raw: Any) -> list[dict[str, Any]]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or len(raw) > 100:
+        raise WebCaptureError("annotations must be a list of at most 100 items.")
+    annotations = []
+    for index, value in enumerate(raw):
+        item = mapping(value, label=f"annotation {index}")
+        validate_keys(item, {"id", "selector", "kind", "text", "padding", "color", "stroke_width", "position", "offset", "strict", "nth", "required"}, label=f"annotation {index}")
+        identifier = str(item.get("id") or f"annotation-{index + 1}")
+        if not CAPTURE_ID_RE.fullmatch(identifier):
+            raise WebCaptureError(f"Invalid annotation id: {identifier}")
+        kind = str(item.get("kind") or "outline")
+        if kind not in {"outline", "label", "arrow", "spotlight"}:
+            raise WebCaptureError(f"Invalid annotation kind: {kind}")
+        color = str(item.get("color") or "#b42318")
+        if not re.fullmatch(r"#[0-9A-Fa-f]{6}", color):
+            raise WebCaptureError(f"Annotation color must be #RRGGBB: {color}")
+        position = str(item.get("position") or "top-right")
+        if position not in {"top-left", "top-right", "bottom-left", "bottom-right", "left", "right"}:
+            raise WebCaptureError(f"Invalid annotation position: {position}")
+        offset = item.get("offset") or [0, 0]
+        if not isinstance(offset, list) or len(offset) != 2 or any(isinstance(part, bool) or not isinstance(part, (int, float)) or abs(part) > 2000 for part in offset):
+            raise WebCaptureError(f"Annotation offset must contain two bounded numbers: {identifier}")
+        annotations.append({
+            "id": identifier,
+            "selector": validate_selector(item.get("selector"), label=f"annotation {identifier} selector"),
+            "kind": kind,
+            "text": str(item.get("text") or ""),
+            "padding": bounded_int(item.get("padding", 6), label=f"annotation {identifier} padding", minimum=0, maximum=500),
+            "color": color.lower(),
+            "stroke_width": bounded_int(item.get("stroke_width", 3), label=f"annotation {identifier} stroke_width", minimum=1, maximum=20),
+            "position": position,
+            "offset": [float(offset[0]), float(offset[1])],
+            "strict": item.get("strict", True) is not False,
+            "nth": bounded_int(item.get("nth", 0), label=f"annotation {identifier} nth", minimum=0, maximum=1000),
+            "required": item.get("required", True) is not False,
+        })
+    return annotations
+
+
+def read_recipe(project: Path, source: Path) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(source.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise WebCaptureError(f"Invalid capture recipe YAML in {relative(project, source)}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise WebCaptureError(f"Capture recipe must be a YAML mapping: {relative(project, source)}")
+    validate_keys(data, {"version", "path", "viewport", "capture", "theme", "waits", "annotations", "inputs", "locale"}, label="capture recipe")
+    if data.get("version") != 1:
+        raise WebCaptureError(f"Unsupported capture recipe version in {relative(project, source)}")
+    inputs = data.get("inputs") or []
+    if not isinstance(inputs, list):
+        raise WebCaptureError("Capture recipe inputs must be a list.")
+    normalized_inputs = [relative(project, safe_relative(project, str(item), label="capture input", must_exist=True)) for item in inputs]
+    locale = str(data.get("locale") or "en-US")
+    if not re.fullmatch(r"[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*", locale):
+        raise WebCaptureError(f"Invalid capture locale: {locale}")
+    return {
+        "version": 1,
+        "path": validate_path(data.get("path")),
+        "viewport": normalize_viewport(data.get("viewport")),
+        "capture": normalize_capture(data.get("capture")),
+        "theme": normalize_theme(data.get("theme")),
+        "waits": normalize_waits(data.get("waits")),
+        "annotations": normalize_annotations(data.get("annotations")),
+        "inputs": normalized_inputs,
+        "locale": locale,
+    }
+
+
+def output_paths(source: Path) -> tuple[Path, Path, Path]:
+    if not source.name.endswith(SOURCE_SUFFIX):
+        raise WebCaptureError(f"Capture source must end with {SOURCE_SUFFIX}: {source}")
+    return source.with_suffix(".png"), source.with_suffix(".svg"), source.with_suffix(".edited.svg")
+
+
+def discover(project: Path) -> list[dict[str, Any]]:
+    assets = project / "assets"
+    records = []
+    for source in sorted(assets.rglob(f"*{SOURCE_SUFFIX}")) if assets.is_dir() else []:
+        if any(part.startswith(".") for part in source.relative_to(project).parts):
+            continue
+        recipe = read_recipe(project, source)
+        png, svg, edited = output_paths(source)
+        records.append({"source": source, "source_path": relative(project, source), "recipe": recipe, "png": png, "svg": svg, "edited": edited})
+    return records
+
+
+def selected_records(project: Path, source: str = "") -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    records = discover(project)
+    if not source:
+        return records, records
+    if not SAFE_SOURCE_RE.fullmatch(source) or source.startswith("/") or ".." in Path(source).parts:
+        raise WebCaptureError("Selected capture source must be a safe project-relative *.capture.yml path.")
+    selected = safe_relative(project, source, label="selected capture source", must_exist=True)
+    matches = [record for record in records if record["source"] == selected]
+    if not matches:
+        raise WebCaptureError(f"Selected file is not a capture recipe under assets/: {source}")
+    return matches, records
+
+
+def load_lock(project: Path) -> dict[str, Any]:
+    path = project / LOCK_PATH
+    if not path.is_file():
+        return {"version": 1, "records": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise WebCaptureError(f"Invalid web capture lock file: {exc}") from exc
+    if not isinstance(data, dict) or data.get("version") != 1 or not isinstance(data.get("records"), dict):
+        raise WebCaptureError("Invalid web-captures.lock.json structure.")
+    return data
+
+
+def write_lock(project: Path, lock: dict[str, Any]) -> None:
+    path = project / LOCK_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock["version"] = 1
+    descriptor, raw_path = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temporary = Path(raw_path)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(json_dump(lock))
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def inspect_image(image: str) -> dict[str, str]:
+    configured_id = os.environ.get("UNALTRAWEB_CAPTURE_IMAGE_ID", "").strip()
+    configured_digest = os.environ.get("UNALTRAWEB_CAPTURE_IMAGE_DIGEST", "").strip()
+    if configured_id or configured_digest:
+        return {"available": "true", "id": configured_id, "digest": configured_digest}
+    if not shutil.which("docker"):
+        return {"available": "false", "id": "", "digest": ""}
+    completed = subprocess.run(["docker", "image", "inspect", image, "--format", '{{.Id}}|{{join .RepoDigests ","}}'], text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=False)
+    if completed.returncode != 0:
+        return {"available": "false", "id": "", "digest": ""}
+    image_id, _, digest = completed.stdout.strip().partition("|")
+    return {"available": "true", "id": image_id, "digest": digest}
+
+
+def selected_image() -> str:
+    return os.environ.get("WEB_CAPTURE_IMAGE", "").strip() or DEFAULT_IMAGE
+
+
+def factory_root() -> Path:
+    configured = os.environ.get("UNALTRAWEB_FACTORY_ROOT", "").strip()
+    return Path(configured).resolve() if configured else Path(__file__).resolve().parents[2]
+
+
+def renderer_files() -> list[Path]:
+    root = factory_root()
+    return [
+        root / "scripts/web_captures/render.py",
+        root / "scripts/web_captures/capture.mjs",
+        root / "scripts/web_captures/Dockerfile",
+        root / "scripts/web_captures/package.json",
+        root / "scripts/web_captures/package-lock.json",
+        root / "_config.yml",
+        root / "_plugins",
+        root / "_layouts",
+        root / "_includes",
+        root / "_sass",
+        root / "assets/js",
+    ]
+
+
+def fingerprint(project: Path, record: dict[str, Any], saved: dict[str, Any] | None = None) -> tuple[str, list[dict[str, str]], dict[str, str]]:
+    dependencies = [record["source"], *[safe_relative(project, item, label="capture input", must_exist=True) for item in record["recipe"]["inputs"]]]
+    signatures = [signature for path in dependencies for signature in path_signatures(project, path)]
+    root = factory_root()
+    renderer = [
+        {"path": str(item.relative_to(root)).replace(os.sep, "/"), "sha256": file_signature(item)["sha256"]}
+        for path in renderer_files() if path.exists()
+        for item in ([path] if path.is_file() else sorted(candidate for candidate in path.rglob("*") if candidate.is_file()))
+    ]
+    image = selected_image()
+    local_identity = inspect_image(image)
+    saved_identity = (saved or {}).get("image_identity") if isinstance((saved or {}).get("image_identity"), dict) else {}
+    identity = local_identity if local_identity["available"] == "true" else saved_identity
+    payload = {"recipe": record["recipe"], "dependencies": signatures, "renderer": renderer, "image": image, "image_identity": identity}
+    return sha256_bytes(canonical_json(payload)), signatures, {"image": image, **identity}
+
+
+def signatures_match(path: Path, saved: Any) -> bool:
+    return isinstance(saved, dict) and path.is_file() and saved.get("sha256") == file_signature(path)["sha256"] and saved.get("size") == path.stat().st_size
+
+
+def svg_metadata(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8")
+    match = SVG_METADATA_RE.search(text)
+    if not match:
+        return None
+    try:
+        value = json.loads(html.unescape(match.group(1)))
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def validate_svg_safety(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    lowered = text.lower()
+    if "<!doctype" in lowered or "<!entity" in lowered:
+        raise WebCaptureError(f"Unsafe executable content in capture SVG: {path}")
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError as exc:
+        raise WebCaptureError(f"Invalid capture SVG XML: {path}: {exc}") from exc
+    for element in root.iter():
+        tag = element.tag.rsplit("}", 1)[-1].lower()
+        if tag not in SVG_ALLOWED_ELEMENTS:
+            raise WebCaptureError(f"Unsupported element in capture SVG: {path}: {tag}")
+        for raw_name, raw_value in element.attrib.items():
+            name = raw_name.rsplit("}", 1)[-1].lower()
+            value = raw_value.strip()
+            lowered_value = value.lower()
+            if name not in SVG_ALLOWED_ATTRIBUTES:
+                raise WebCaptureError(f"Unsupported attribute in capture SVG: {path}: {name}")
+            if "@import" in lowered_value or "javascript:" in lowered_value or "expression(" in lowered_value:
+                raise WebCaptureError(f"Unsafe attribute in capture SVG: {path}: {name}")
+            if name == "href" and not (value.startswith("data:image/png;base64,") or value.startswith("#")):
+                raise WebCaptureError(f"External reference in capture SVG: {path}")
+            without_local_urls = re.sub(r"url\(\s*['\"]?#[A-Za-z_][-:.A-Za-z0-9_]*['\"]?\s*\)", "", lowered_value)
+            if "url(" in without_local_urls:
+                raise WebCaptureError(f"External CSS reference in capture SVG: {path}")
+            if name == "style":
+                declarations = [part.strip() for part in value.split(";") if part.strip()]
+                for declaration in declarations:
+                    property_name, separator, _ = declaration.partition(":")
+                    if not separator or property_name.strip().lower() not in SVG_ALLOWED_STYLE_PROPERTIES:
+                        raise WebCaptureError(f"Unsupported style in capture SVG: {path}: {property_name.strip()}")
+
+
+def edited_state(record: dict[str, Any], fingerprint_value: str = "") -> dict[str, Any]:
+    edited = record["edited"]
+    if not edited.is_file():
+        return {"status": "none", "path": ""}
+    validate_svg_safety(edited)
+    metadata = svg_metadata(edited)
+    png_hash = file_signature(record["png"])["sha256"] if record["png"].is_file() else ""
+    if not metadata or not metadata.get("png_sha256") or not metadata.get("fingerprint"):
+        return {"status": "invalid", "path": str(edited)}
+    current = metadata["png_sha256"] == png_hash and (not fingerprint_value or metadata["fingerprint"] == fingerprint_value)
+    return {"status": "current" if current else "stale", "path": str(edited), "png_sha256": metadata["png_sha256"], "fingerprint": metadata["fingerprint"]}
+
+
+def orphaned_artifacts(project: Path, records: list[dict[str, Any]]) -> list[str]:
+    expected = {relative(project, path) for record in records for path in [record["png"], record["svg"], record["edited"]]}
+    assets = project / "assets"
+    actual = {
+        relative(project, path)
+        for pattern in ["*.capture.png", "*.capture.svg", "*.capture.edited.svg"]
+        for path in (assets.rglob(pattern) if assets.is_dir() else [])
+    }
+    return sorted(actual - expected)
+
+
+def status(project: Path, source: str = "") -> dict[str, Any]:
+    selected, all_records = selected_records(project, source)
+    lock = load_lock(project)
+    items = []
+    for record in selected:
+        saved = lock["records"].get(record["source_path"], {})
+        current_fingerprint, dependencies, image = fingerprint(project, record, saved)
+        png_valid = signatures_match(record["png"], saved.get("png"))
+        svg_valid = signatures_match(record["svg"], saved.get("svg"))
+        if record["svg"].is_file():
+            validate_svg_safety(record["svg"])
+        edited = edited_state(record, current_fingerprint)
+        current = bool(saved and saved.get("fingerprint") == current_fingerprint and png_valid and svg_valid and edited["status"] in {"none", "current"})
+        reason = "current"
+        if not saved:
+            reason = "not_rendered"
+        elif saved.get("fingerprint") != current_fingerprint:
+            reason = "source_or_environment_changed"
+        elif not record["png"].is_file():
+            reason = "png_missing"
+        elif not png_valid:
+            reason = "png_modified"
+        elif not record["svg"].is_file():
+            reason = "svg_missing"
+        elif not svg_valid:
+            reason = "svg_modified"
+        elif edited["status"] == "stale":
+            reason = "edited_override_stale"
+        elif edited["status"] == "invalid":
+            reason = "edited_override_invalid"
+        effective = record["edited"] if record["edited"].is_file() else record["svg"]
+        items.append({
+            "source": record["source_path"],
+            "path": record["recipe"]["path"],
+            "png": relative(project, record["png"]),
+            "svg": relative(project, record["svg"]),
+            "edited_svg": relative(project, record["edited"]),
+            "effective_svg": relative(project, effective),
+            "edited": {**edited, "path": relative(project, record["edited"]) if record["edited"].is_file() else ""},
+            "image": image,
+            "dependencies": dependencies,
+            "fingerprint": current_fingerprint,
+            "current": current,
+            "reason": reason,
+        })
+    known = {record["source_path"] for record in all_records}
+    orphaned = sorted(path for path in lock["records"] if path not in known)
+    orphaned_files = orphaned_artifacts(project, all_records)
+    return {
+        "project": str(project),
+        "lock": str(LOCK_PATH) if (project / LOCK_PATH).is_file() else "",
+        "captures": items,
+        "capture_count": len(items),
+        "current_count": sum(1 for item in items if item["current"]),
+        "orphaned_records": orphaned,
+        "orphaned_artifacts": orphaned_files,
+        "ok": all(item["current"] for item in items) and not orphaned and not orphaned_files,
+    }
+
+
+def validate_base_url(raw: str) -> str:
+    value = raw.strip().rstrip("/")
+    parsed = urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.username or parsed.password or parsed.query or parsed.fragment or parsed.path not in {"", "/"}:
+        raise WebCaptureError("Base URL must be an http(s) origin without credentials, path, query, or fragment.")
+    hostname = (parsed.hostname or "").lower()
+    service_host = os.environ.get("WEB_CAPTURE_SERVICE_HOST", "").strip().lower()
+    network = os.environ.get("WEB_CAPTURE_DOCKER_NETWORK", "").strip()
+    allowed = bool(service_host and hostname == service_host and network not in {"", "host", "none"})
+    if not allowed:
+        raise WebCaptureError("Base URL must use the declared service host on an isolated Docker network.")
+    if not internal_network(network):
+        raise WebCaptureError(f"Browser capture requires an internal Docker network: {network}")
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def internal_network(network: str) -> bool:
+    if not shutil.which("docker") or network in {"", "host", "none"}:
+        return False
+    completed = subprocess.run(
+        ["docker", "network", "inspect", network, "--format", "{{.Internal}}"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return completed.returncode == 0 and completed.stdout.strip().lower() == "true"
+
+
+def build_image(image: str) -> None:
+    available = inspect_image(image)["available"] == "true"
+    if available:
+        return
+    if image != DEFAULT_IMAGE:
+        completed = subprocess.run(["docker", "pull", image], check=False)
+        if completed.returncode != 0:
+            raise WebCaptureError(f"Could not pull web capture image: {image}")
+        return
+    root = factory_root()
+    command = ["docker", "build"]
+    network = os.environ.get("WEB_CAPTURE_DOCKER_BUILD_NETWORK", "").strip()
+    if network:
+        command.extend(["--network", network])
+    command.extend(["-f", str(root / "scripts/web_captures/Dockerfile"), "-t", image, str(root)])
+    completed = subprocess.run(command, check=False)
+    if completed.returncode != 0:
+        raise WebCaptureError(f"Could not build web capture image: {image}")
+
+
+def png_dimensions(path: Path) -> tuple[int, int]:
+    data = path.read_bytes()[:24]
+    if len(data) != 24 or data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise WebCaptureError(f"Invalid PNG output: {path}")
+    return struct.unpack(">II", data[16:24])
+
+
+def xml(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def annotation_box(annotation: dict[str, Any], origin: dict[str, float], scale: float) -> dict[str, float]:
+    box = annotation["box"]
+    padding = annotation["padding"]
+    return {
+        "x": (box["x"] - origin["x"] - padding) * scale,
+        "y": (box["y"] - origin["y"] - padding) * scale,
+        "width": (box["width"] + padding * 2) * scale,
+        "height": (box["height"] + padding * 2) * scale,
+    }
+
+
+def label_position(box: dict[str, float], position: str, offset: list[float], scale: float) -> tuple[float, float]:
+    x = box["x"] + box["width"]
+    y = box["y"] - 12 * scale
+    if "left" in position:
+        x = box["x"]
+    if "bottom" in position:
+        y = box["y"] + box["height"] + 26 * scale
+    if position == "left":
+        x, y = box["x"] - 16 * scale, box["y"] + box["height"] / 2
+    if position == "right":
+        x, y = box["x"] + box["width"] + 16 * scale, box["y"] + box["height"] / 2
+    return x + offset[0] * scale, y + offset[1] * scale
+
+
+def svg_for(project: Path, record: dict[str, Any], png: Path, worker: dict[str, Any], fingerprint_value: str) -> str:
+    width, height = png_dimensions(png)
+    scale = float(worker["device_scale_factor"])
+    metadata = {
+        "schema": 1,
+        "source": record["source_path"],
+        "png_sha256": file_signature(png)["sha256"],
+        "fingerprint": fingerprint_value,
+        "path": record["recipe"]["path"],
+        "viewport": record["recipe"]["viewport"],
+        "browser_version": worker.get("browser_version", ""),
+    }
+    background = base64.b64encode(png.read_bytes()).decode("ascii")
+    highlights: list[str] = []
+    arrows: list[str] = []
+    labels: list[str] = []
+    notes: list[str] = []
+    for annotation in worker.get("annotations", []):
+        box = annotation_box(annotation, worker["origin"], scale)
+        if box["x"] + box["width"] <= 0 or box["y"] + box["height"] <= 0 or box["x"] >= width or box["y"] >= height:
+            if annotation.get("required", True):
+                raise WebCaptureError(f"Annotation is outside the captured area: {annotation['id']}")
+            continue
+        identifier = xml(annotation["id"])
+        selector = xml(annotation["selector"])
+        color = annotation["color"]
+        stroke = annotation["stroke_width"] * scale
+        rect = f'<rect x="{box["x"]:.2f}" y="{box["y"]:.2f}" width="{box["width"]:.2f}" height="{box["height"]:.2f}" rx="{6 * scale:.2f}" fill="none" stroke="{color}" stroke-width="{stroke:.2f}"/>'
+        if annotation["kind"] == "spotlight":
+            path = f'M0 0H{width}V{height}H0Z M{box["x"]:.2f} {box["y"]:.2f}h{box["width"]:.2f}v{box["height"]:.2f}h-{box["width"]:.2f}Z'
+            highlights.append(f'<g id="annotation-{identifier}" data-selector="{selector}"><path d="{path}" fill="#000000" fill-opacity="0.48" fill-rule="evenodd"/>{rect}</g>')
+        else:
+            highlights.append(f'<g id="annotation-{identifier}" data-selector="{selector}">{rect}</g>')
+        text = annotation.get("text", "")
+        if text:
+            lx, ly = label_position(box, annotation["position"], annotation["offset"], scale)
+            text_width = max(44, min(420, len(text) * 8 + 20)) * scale
+            text_height = 30 * scale
+            lx = max(4 * scale, min(lx, width - text_width - 4 * scale))
+            ly = max(text_height, min(ly, height - 4 * scale))
+            label = (
+                f'<g id="label-{identifier}" data-selector="{selector}">'
+                f'<rect x="{lx:.2f}" y="{ly - text_height:.2f}" width="{text_width:.2f}" height="{text_height:.2f}" rx="{5 * scale:.2f}" fill="{color}"/>'
+                f'<text x="{lx + 10 * scale:.2f}" y="{ly - 9 * scale:.2f}" fill="#ffffff" font-family="Arial, sans-serif" font-size="{14 * scale:.2f}" font-weight="600">{xml(text)}</text></g>'
+            )
+            labels.append(label)
+            if annotation["kind"] == "arrow":
+                cx = box["x"] + box["width"] / 2
+                cy = box["y"] + box["height"] / 2
+                arrows.append(f'<path id="arrow-{identifier}" d="M{lx + text_width / 2:.2f} {ly:.2f} L{cx:.2f} {cy:.2f}" fill="none" stroke="{color}" stroke-width="{stroke:.2f}" marker-end="url(#arrowhead)"/>')
+        if annotation["kind"] == "label" and not text:
+            notes.append(f'<!-- Empty label annotation: {identifier} -->')
+    metadata_text = xml(json.dumps(metadata, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        f'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="{width}" height="{height}" viewBox="0 0 {width} {height}">\n'
+        f'  <metadata id="unaltraweb-capture">{metadata_text}</metadata>\n'
+        '  <defs><marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#b42318"/></marker></defs>\n'
+        f'  <g id="background" inkscape:groupmode="layer" inkscape:label="Background"><image width="{width}" height="{height}" href="data:image/png;base64,{background}"/></g>\n'
+        f'  <g id="highlights" inkscape:groupmode="layer" inkscape:label="Highlights">{"".join(highlights)}</g>\n'
+        f'  <g id="arrows" inkscape:groupmode="layer" inkscape:label="Arrows">{"".join(arrows)}</g>\n'
+        f'  <g id="labels" inkscape:groupmode="layer" inkscape:label="Labels">{"".join(labels)}</g>\n'
+        f'  <g id="notes" inkscape:groupmode="layer" inkscape:label="Notes">{"".join(notes)}</g>\n'
+        '</svg>\n'
+    )
+
+
+def worker_config(record: dict[str, Any], base_url: str, png_path: str, result_path: str) -> dict[str, Any]:
+    recipe = record["recipe"]
+    return {
+        "url": base_url + recipe["path"],
+        "viewport": recipe["viewport"],
+        "capture": recipe["capture"],
+        "theme": recipe["theme"],
+        "waits": recipe["waits"],
+        "annotations": recipe["annotations"],
+        "locale": recipe["locale"],
+        "png_path": png_path,
+        "result_path": result_path,
+    }
+
+
+def run_worker(project: Path, image: str, config_path: Path) -> None:
+    network = os.environ.get("WEB_CAPTURE_DOCKER_NETWORK", "").strip()
+    if not internal_network(network):
+        raise WebCaptureError("Browser capture requires a named isolated Docker network.")
+    command = [
+        "docker", "run", "--rm", "--user", f"{os.getuid()}:{os.getgid()}", "--network", network, "--ipc=host",
+        "--read-only", "--cap-drop", "ALL", "--security-opt", "no-new-privileges", "--pids-limit", "256", "--cpus", "2", "--memory", "2g",
+        "--tmpfs", "/tmp:rw,noexec,nosuid,size=512m", "-e", "HOME=/tmp", "-v", f"{project}:/project:rw", "-w", "/project", image,
+        "/project/" + relative(project, config_path),
+    ]
+    completed = subprocess.run(command, check=False)
+    if completed.returncode != 0:
+        raise WebCaptureError(f"Browser capture failed with exit code {completed.returncode}.")
+
+
+def publish(record: dict[str, Any], png_temp: Path, svg_text: str, *, confirm_overwrite: bool, owned: bool) -> None:
+    png = record["png"]
+    svg = record["svg"]
+    if not owned and (png.exists() or svg.exists()) and not confirm_overwrite:
+        raise WebCaptureError(f"Refusing to replace unmanaged capture outputs for {record['source_path']}; rerun with --confirm-overwrite after review.")
+    png.parent.mkdir(parents=True, exist_ok=True)
+    token = secrets.token_hex(6)
+    svg_temp = svg.with_name(f".{svg.name}.{token}.tmp")
+    png_stage = png.with_name(f".{png.name}.{token}.tmp")
+    png_backup = png.with_name(f".{png.name}.{token}.backup")
+    svg_backup = svg.with_name(f".{svg.name}.{token}.backup")
+    shutil.copy2(png_temp, png_stage)
+    svg_temp.write_text(svg_text, encoding="utf-8")
+    try:
+        if png.exists():
+            os.replace(png, png_backup)
+        if svg.exists():
+            os.replace(svg, svg_backup)
+        os.replace(png_stage, png)
+        os.replace(svg_temp, svg)
+    except Exception:
+        png.unlink(missing_ok=True)
+        svg.unlink(missing_ok=True)
+        if png_backup.exists():
+            os.replace(png_backup, png)
+        if svg_backup.exists():
+            os.replace(svg_backup, svg)
+        raise
+    finally:
+        for path in [png_stage, svg_temp, png_backup, svg_backup]:
+            path.unlink(missing_ok=True)
+
+
+@contextlib.contextmanager
+def project_lock(project: Path):
+    root = project / "tmp" / "web-captures"
+    root.mkdir(parents=True, exist_ok=True)
+    with (root / ".render.lock").open("w", encoding="utf-8") as stream:
+        fcntl.flock(stream.fileno(), fcntl.LOCK_EX)
+        yield
+
+
+def render(project: Path, base_url: str, source: str = "", confirm_overwrite: bool = False) -> dict[str, Any]:
+    base_url = validate_base_url(base_url)
+    selected, _ = selected_records(project, source)
+    image = selected_image()
+    build_image(image)
+    lock = load_lock(project)
+    rendered = []
+    with project_lock(project):
+        for record in selected:
+            saved = lock["records"].get(record["source_path"], {})
+            current_fingerprint, dependencies, image_state = fingerprint(project, record, saved)
+            with tempfile.TemporaryDirectory(prefix=f"{record['source'].stem}-", dir=project / "tmp" / "web-captures") as temporary_raw:
+                temporary = Path(temporary_raw)
+                png_temp = temporary / "capture.png"
+                result_temp = temporary / "result.json"
+                config_temp = temporary / "config.json"
+                config_temp.write_text(json_dump(worker_config(record, base_url, "/project/" + relative(project, png_temp), "/project/" + relative(project, result_temp))), encoding="utf-8")
+                run_worker(project, image, config_temp)
+                if not png_temp.is_file() or not result_temp.is_file():
+                    raise WebCaptureError(f"Browser worker did not produce capture outputs for {record['source_path']}.")
+                worker = json.loads(result_temp.read_text(encoding="utf-8"))
+                svg_text = svg_for(project, record, png_temp, worker, current_fingerprint)
+                publish(record, png_temp, svg_text, confirm_overwrite=confirm_overwrite, owned=bool(saved))
+            identity = inspect_image(image)
+            lock["records"][record["source_path"]] = {
+                "fingerprint": current_fingerprint,
+                "dependencies": dependencies,
+                "image": image,
+                "image_identity": identity,
+                "png": {"path": relative(project, record["png"]), **file_signature(record["png"])},
+                "svg": {"path": relative(project, record["svg"]), **file_signature(record["svg"])},
+                "captured_at": utc_now(),
+                "final_path": urlsplit(worker.get("final_url", "")).path,
+                "browser_version": worker.get("browser_version", ""),
+            }
+            write_lock(project, lock)
+            rendered.append({"source": record["source_path"], "png": relative(project, record["png"]), "svg": relative(project, record["svg"]), "effective_svg": relative(project, record["edited"] if record["edited"].is_file() else record["svg"]), "annotations": len(worker.get("annotations", []))})
+    return {"project": str(project), "rendered": rendered, "rendered_count": len(rendered), "ok": True}
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(prog="unaltraweb-web-captures")
+    root.add_argument("command", choices=["status", "check", "render"])
+    root.add_argument("--project", default=".")
+    root.add_argument("--source", default="")
+    root.add_argument("--base-url", default="")
+    root.add_argument("--confirm-overwrite", action="store_true")
+    return root
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    project = Path(args.project).expanduser().resolve()
+    try:
+        if args.command in {"status", "check"}:
+            result = status(project, source=args.source)
+        else:
+            if not args.base_url:
+                raise WebCaptureError("render requires --base-url for a trusted running preview.")
+            result = render(project, args.base_url, source=args.source, confirm_overwrite=args.confirm_overwrite)
+        print(json_dump(result), end="")
+        return 0 if args.command == "status" or result.get("ok") else 1
+    except WebCaptureError as exc:
+        print(json_dump({"project": str(project), "ok": False, "error": str(exc)}), end="")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/unaltraweb_mcp/cli.py
+++ b/src/unaltraweb_mcp/cli.py
@@ -63,7 +63,7 @@ def cmd_mcp(args: argparse.Namespace) -> int:
     if command == "site-context":
         return print_json(tools.site_context(project, factory))
     if command == "site-check":
-        return print_json({"profile": tools.profile_check(project), "language": tools.language_policy(project), "approval": tools.content_approval_inventory(project), "translation": tools.translation_plan(project), "freshness": tools.content_freshness_check(project), "computations": tools.manual_computation_status(project, factory), "bibliography": tools.bibliography_inventory(project), "build_health": tools.build_health(project)})
+        return print_json({"profile": tools.profile_check(project), "language": tools.language_policy(project), "approval": tools.content_approval_inventory(project), "translation": tools.translation_plan(project), "freshness": tools.content_freshness_check(project), "computations": tools.manual_computation_status(project, factory), "web_captures": tools.web_capture_status(project, factory), "bibliography": tools.bibliography_inventory(project), "build_health": tools.build_health(project)})
     if command == "profile-check":
         return print_json(tools.profile_check(project))
     if command == "manual-source-quality-check":
@@ -78,6 +78,12 @@ def cmd_mcp(args: argparse.Namespace) -> int:
         return print_json(tools.manual_computation_check(project, factory, source=args.source), enforce_ok=True)
     if command == "manual-computation-render":
         return print_json(tools.manual_computation_render(project, factory, source=args.source, confirm_overwrite=args.confirm_overwrite))
+    if command == "web-capture-status":
+        return print_json(tools.web_capture_status(project, factory, source=args.source))
+    if command == "web-capture-check":
+        return print_json(tools.web_capture_check(project, factory, source=args.source), enforce_ok=True)
+    if command == "web-capture-render":
+        return print_json(tools.web_capture_render(project, factory, source=args.source, confirm_overwrite=args.confirm_overwrite))
     if command == "manual-pdf-status":
         return print_json(tools.manual_pdf_status(project, language=args.language))
     if command == "manual-pdf-build":
@@ -148,6 +154,14 @@ def build_parser() -> argparse.ArgumentParser:
     computation_render = mcp_sub.add_parser("manual-computation-render")
     computation_render.add_argument("--source", default="")
     computation_render.add_argument("--confirm-overwrite", action="store_true")
+
+    for name in ["web-capture-status", "web-capture-check"]:
+        web_capture = mcp_sub.add_parser(name)
+        web_capture.add_argument("--source", default="")
+
+    web_capture_render = mcp_sub.add_parser("web-capture-render")
+    web_capture_render.add_argument("--source", default="")
+    web_capture_render.add_argument("--confirm-overwrite", action="store_true")
 
     for name in ["manual-pdf-status", "manual-pdf-build"]:
         manual_pdf = mcp_sub.add_parser(name)

--- a/src/unaltraweb_mcp/mcp_server.py
+++ b/src/unaltraweb_mcp/mcp_server.py
@@ -56,7 +56,8 @@ def run_server(project: Path, factory: Path) -> None:
         instructions=(
             "For unaltremanual work, inspect manual_authoring_capabilities before editing. "
             "When a chapter has an executable .qmd, .Rmd, .R, .py, or .ipynb source, edit that source rather than its generated .md. "
-            "Run manual_computation_status and render explicitly after source or input changes; builds must not proceed with stale generated Markdown or figures."
+            "Run manual_computation_status and render explicitly after source or input changes; builds must not proceed with stale generated Markdown or figures. "
+            "For selector-based screenshots, edit the .capture.yml recipe, preserve the original PNG, and never overwrite .capture.edited.svg without approval."
         ),
     )
 
@@ -89,6 +90,11 @@ def run_server(project: Path, factory: Path) -> None:
     def manual_computations_resource() -> str:
         """Executable chapter sources, selected images, generated outputs, and freshness state."""
         return tools.dumps(tools.manual_computation_status(project, factory))
+
+    @mcp.resource("web://web-captures")
+    def web_captures_resource() -> str:
+        """Versioned selector-based screenshot recipes, PNG sources, annotated SVGs, and freshness state."""
+        return tools.dumps(tools.web_capture_status(project, factory))
 
     @mcp.resource("web://profile-prune-plan")
     def profile_prune_plan_resource() -> str:
@@ -215,7 +221,7 @@ def run_server(project: Path, factory: Path) -> None:
     @mcp.tool()
     def site_check(max_bibliometrics_age_days: int = 180) -> dict[str, Any]:
         """Run local profile, freshness, bibliography, bibliometrics, and build-state checks without network access."""
-        return {"profile": tools.profile_check(project), "language": tools.language_policy(project), "approval": tools.content_approval_inventory(project), "translation": tools.translation_plan(project), "freshness": tools.content_freshness_check(project, max_bibliometrics_age_days), "computations": tools.manual_computation_status(project, factory), "bibliography": tools.bibliography_inventory(project), "build_health": tools.build_health(project)}
+        return {"profile": tools.profile_check(project), "language": tools.language_policy(project), "approval": tools.content_approval_inventory(project), "translation": tools.translation_plan(project), "freshness": tools.content_freshness_check(project, max_bibliometrics_age_days), "computations": tools.manual_computation_status(project, factory), "web_captures": tools.web_capture_status(project, factory), "bibliography": tools.bibliography_inventory(project), "build_health": tools.build_health(project)}
 
     @mcp.tool()
     def profile_check() -> dict[str, Any]:
@@ -251,6 +257,21 @@ def run_server(project: Path, factory: Path) -> None:
     def manual_computation_render(source: str = "", confirm_overwrite: bool = False) -> dict[str, Any]:
         """Execute trusted manual sources in network-disabled containers and update versioned Markdown and figures."""
         return tools.manual_computation_render(project, factory, source=source, confirm_overwrite=confirm_overwrite)
+
+    @mcp.tool()
+    def web_capture_status(source: str = "") -> dict[str, Any]:
+        """Inspect selector-based web capture recipes, generated PNG/SVG artefacts, edited overrides, and freshness."""
+        return tools.web_capture_status(project, factory, source=source)
+
+    @mcp.tool()
+    def web_capture_check(source: str = "") -> dict[str, Any]:
+        """Fail when a web capture PNG/SVG is missing, modified, stale, orphaned, or shadowed by a stale edited SVG."""
+        return tools.web_capture_check(project, factory, source=source)
+
+    @mcp.tool()
+    def web_capture_render(source: str = "", confirm_overwrite: bool = False) -> dict[str, Any]:
+        """Start an isolated project preview and publish original PNG plus editable annotated SVG artefacts."""
+        return tools.web_capture_render(project, factory, source=source, confirm_overwrite=confirm_overwrite)
 
     @mcp.tool()
     def manual_pdf_status(language: str = "") -> dict[str, Any]:

--- a/src/unaltraweb_mcp/site_tools.py
+++ b/src/unaltraweb_mcp/site_tools.py
@@ -346,6 +346,7 @@ def content_inventory(project: Path) -> dict[str, Any]:
         for path in (project / directory).rglob("*")
         if (project / directory).is_dir() and path.is_file() and path.suffix.lower() in COMPUTATION_SUFFIXES
     )
+    web_capture_sources = sorted((project / "assets").rglob("*.capture.yml")) if (project / "assets").is_dir() else []
     return {
         "project": str(project),
         "generated_at": utc_now(),
@@ -353,6 +354,7 @@ def content_inventory(project: Path) -> dict[str, Any]:
         "data_files": [rel(project, path) for path in data_files if path.is_file()],
         "assets_present": (project / "assets").is_dir(),
         "computation_sources": [rel(project, path) for path in computation_sources],
+        "web_capture_sources": [rel(project, path) for path in web_capture_sources],
     }
 
 
@@ -1017,9 +1019,16 @@ def manual_authoring_capabilities(project: Path) -> dict[str, Any]:
                 "pdf": "uses the same checked generated Markdown and figures as the web build",
                 "guidance": "When an executable source exists, edit it rather than the generated .md. Declare one r or python engine per source, list non-code inputs, render explicitly, and never publish while manual_computation_check reports stale outputs.",
             },
+            {
+                "id": "web_captures",
+                "syntax": ["page.capture.yml -> page.capture.png + page.capture.svg", "page.capture.edited.svg"],
+                "web": "publishes the generated or author-edited self-contained SVG; recipe and original PNG remain source artefacts",
+                "pdf": "uses the same generated or author-edited SVG as the web build",
+                "guidance": "Define local paths, waits, themes, and CSS selectors in a .capture.yml recipe. Preserve the original PNG, edit vector layers only in .capture.edited.svg, and never publish while web_capture_check reports stale outputs or an obsolete edited override.",
+            },
         ],
         "web_only_or_pdf_review_required": ["tabs", "details", "interactive charts", "interactive maps", "galleries", "audio", "video", "arbitrary Liquid figure includes"],
-        "quality_tools": ["manual_source_quality_check", "manual_editorial_quality_check", "build_site", "manual_pdf_build"],
+        "quality_tools": ["manual_source_quality_check", "manual_editorial_quality_check", "manual_computation_check", "web_capture_check", "build_site", "manual_pdf_build"],
         "source_guides": [
             "docs/agents/manual-authoring-components.md",
             "plugins/unaltraweb-site/skills/manual-pedagogical-writing/SKILL.md",
@@ -1511,6 +1520,31 @@ def manual_computation_render(project: Path, factory: Path, source: str = "", *,
     return run_factory_make(factory, project, "manual-compute-render", env=env)
 
 
+def _web_capture_env(source: str = "") -> dict[str, str]:
+    env: dict[str, str] = {}
+    value = source.strip()
+    if value:
+        if Path(value).is_absolute() or ".." in Path(value).parts or not re.fullmatch(r"[A-Za-z0-9_./-]+\.capture\.yml", value):
+            raise ValueError("Web capture source must be a safe project-relative *.capture.yml path.")
+        env["WEB_CAPTURE_SOURCE"] = value
+    return env
+
+
+def web_capture_status(project: Path, factory: Path, source: str = "") -> dict[str, Any]:
+    return run_factory_make(factory, project, "web-capture-status", env=_web_capture_env(source))
+
+
+def web_capture_check(project: Path, factory: Path, source: str = "") -> dict[str, Any]:
+    return run_factory_make(factory, project, "web-capture-check", env=_web_capture_env(source))
+
+
+def web_capture_render(project: Path, factory: Path, source: str = "", *, confirm_overwrite: bool = False) -> dict[str, Any]:
+    env = _web_capture_env(source)
+    if confirm_overwrite:
+        env["WEB_CAPTURE_CONFIRM_OVERWRITE"] = "1"
+    return run_make(project_path(project), "web-capture-render", env=env)
+
+
 def build_site(project: Path, site_profile: str = "") -> dict[str, Any]:
     args = [f"SITE_PROFILE={site_profile}"] if site_profile else []
     return run_make(project_path(project), "build", extra_args=args)
@@ -1602,15 +1636,16 @@ def site_context(project: Path, factory: Path | None = None) -> dict[str, Any]:
         "bibliography": bibliography_inventory(project),
         "bibliometrics": bibliometrics_status(project),
         "build_health": build_health(project),
+        "web_captures": web_capture_status(project, factory) if factory else {},
         "factory": str(factory) if factory else "",
     }
 
 
 def list_tools() -> dict[str, Any]:
     return {
-        "resources": ["web://site-context", "web://starter-templates", "web://profile-contract", "web://manual-writing-guidance", "web://manual-authoring-components", "web://manual-computations", "web://profile-prune-plan", "web://content-inventory", "web://language-policy", "web://content-approval", "web://translation-plan", "web://bibliography", "web://bibliometrics", "web://build-health", "web://prompts"],
+        "resources": ["web://site-context", "web://starter-templates", "web://profile-contract", "web://manual-writing-guidance", "web://manual-authoring-components", "web://manual-computations", "web://web-captures", "web://profile-prune-plan", "web://content-inventory", "web://language-policy", "web://content-approval", "web://translation-plan", "web://bibliography", "web://bibliometrics", "web://build-health", "web://prompts"],
         "prompts": ["start_site_session", "content_update", "edit_default_content", "manual_teaching_materials", "manual_style_audit", "manual_structure_audit", "translation_prepublish", "project_site_update", "documentation_update", "bibliography_entry", "bibliometrics_refresh", "build_and_review"],
-        "tools": ["initialize_site", "starter_templates", "site_context", "site_check", "profile_check", "manual_source_quality_check", "manual_editorial_quality_check", "manual_authoring_capabilities", "manual_computation_status", "manual_computation_check", "manual_computation_render", "manual_pdf_status", "manual_pdf_build", "manual_pdf_publish", "profile_prune_plan", "profile_prune", "content_inventory", "language_policy", "content_approval_inventory", "translation_plan", "content_freshness_check", "bibliography_inventory", "bibliography_add_entry", "bibliometrics_check", "bibliometrics_update", "bibliometrics_fetch_scimago", "build_site", "build_health", "http_check"],
+        "tools": ["initialize_site", "starter_templates", "site_context", "site_check", "profile_check", "manual_source_quality_check", "manual_editorial_quality_check", "manual_authoring_capabilities", "manual_computation_status", "manual_computation_check", "manual_computation_render", "web_capture_status", "web_capture_check", "web_capture_render", "manual_pdf_status", "manual_pdf_build", "manual_pdf_publish", "profile_prune_plan", "profile_prune", "content_inventory", "language_policy", "content_approval_inventory", "translation_plan", "content_freshness_check", "bibliography_inventory", "bibliography_add_entry", "bibliometrics_check", "bibliometrics_update", "bibliometrics_fetch_scimago", "build_site", "build_health", "http_check"],
     }
 
 

--- a/test/manual_pdf/test_build_pdf.py
+++ b/test/manual_pdf/test_build_pdf.py
@@ -83,6 +83,38 @@ class ManualPdfBuilderTests(unittest.TestCase):
         self.assertIn("Table: A useful table", result)
         self.assertIn("![Detailed flow](assets/diagrams/flow.mmd.edited.svg)", result)
 
+    def test_transform_prefers_edited_web_capture_svg(self) -> None:
+        capture = self.project / "assets/captures/sidebar.capture.yml"
+        capture.parent.mkdir(parents=True)
+        capture.write_text("version: 1\npath: /en/\n", encoding="utf-8")
+        Path(str(capture).removesuffix(".yml") + ".svg").write_text("<svg/>", encoding="utf-8")
+        Path(str(capture).removesuffix(".yml") + ".edited.svg").write_text("<svg/>", encoding="utf-8")
+        source = self.project / "_chapters/en/chapter.md"
+
+        result = manual_pdf.transform_markdown(
+            self.project,
+            '![Sidebar]({{ site.baseurl }}/assets/captures/sidebar.capture.yml "Annotated sidebar")',
+            source,
+        )
+
+        self.assertIn("![Annotated sidebar](assets/captures/sidebar.capture.edited.svg)", result)
+
+    def test_transform_rejects_unsafe_edited_web_capture_svg(self) -> None:
+        capture = self.project / "assets/captures/sidebar.capture.yml"
+        capture.parent.mkdir(parents=True)
+        capture.write_text("version: 1\npath: /en/\n", encoding="utf-8")
+        Path(str(capture).removesuffix(".yml") + ".edited.svg").write_text(
+            '<svg><style>@import url("https://example.com/x.css");</style></svg>',
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(manual_pdf.ManualPdfError, "(?:Unsafe|Unsupported) web capture SVG"):
+            manual_pdf.transform_markdown(
+                self.project,
+                '![Sidebar](assets/captures/sidebar.capture.yml "Annotated sidebar")',
+                self.project / "_chapters/en/chapter.md",
+            )
+
     def test_unknown_liquid_fails_instead_of_dropping_content(self) -> None:
         source = self.project / "_chapters/en/chapter.md"
         with self.assertRaisesRegex(manual_pdf.ManualPdfError, "Unsupported Liquid"):

--- a/test/test_mcp_manual_editorial.py
+++ b/test/test_mcp_manual_editorial.py
@@ -111,6 +111,8 @@ Una font oficial ha d'identificar l'organisme responsable, la data de referènci
         self.assertIn("manual_authoring_capabilities", inventory["tools"])
         self.assertIn("manual_computation_status", inventory["tools"])
         self.assertIn("executable_sources", components)
+        self.assertIn("web_captures", components)
+        self.assertIn("web_capture_check", result["quality_tools"])
 
     def test_source_quality_warns_about_fake_fourth_level_headings(self) -> None:
         (self.project / "_chapters/ca/chapter.md").write_text(

--- a/test/test_mcp_web_captures.py
+++ b/test/test_mcp_web_captures.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from unaltraweb_mcp import cli, site_tools
+
+
+class WebCapturesMcpTests(unittest.TestCase):
+    @patch("unaltraweb_mcp.site_tools.run_factory_make")
+    def test_status_delegates_to_fixed_factory_target(self, run_factory_make) -> None:
+        run_factory_make.return_value = {"ok": True}
+
+        site_tools.web_capture_status(Path("/tmp/site"), Path("/tmp/factory"), source="assets/captures/home.capture.yml")
+
+        run_factory_make.assert_called_once_with(
+            Path("/tmp/factory"),
+            Path("/tmp/site"),
+            "web-capture-status",
+            env={"WEB_CAPTURE_SOURCE": "assets/captures/home.capture.yml"},
+        )
+
+    @patch("unaltraweb_mcp.site_tools.run_make")
+    def test_render_delegates_to_project_isolated_workflow(self, run_make) -> None:
+        run_make.return_value = {"ok": True}
+
+        site_tools.web_capture_render(
+            Path("/tmp/site"),
+            Path("/tmp/factory"),
+            source="assets/captures/home.capture.yml",
+            confirm_overwrite=True,
+        )
+
+        run_make.assert_called_once_with(
+            Path("/tmp/site").resolve(),
+            "web-capture-render",
+            env={
+                "WEB_CAPTURE_SOURCE": "assets/captures/home.capture.yml",
+                "WEB_CAPTURE_CONFIRM_OVERWRITE": "1",
+            },
+        )
+
+    def test_rejects_unsafe_source(self) -> None:
+        for source in ["../outside.capture.yml", "$(shell touch /tmp/pwned).capture.yml", "assets/home.yml"]:
+            with self.subTest(source=source), self.assertRaises(ValueError):
+                site_tools.web_capture_status(Path("/tmp/site"), Path("/tmp/factory"), source=source)
+
+    @patch("unaltraweb_mcp.cli.tools.web_capture_check", return_value={"ok": False})
+    def test_cli_check_returns_nonzero_when_stale(self, _check) -> None:
+        args = argparse.Namespace(project="/tmp/site", mcp_command="web-capture-check", source="")
+
+        self.assertEqual(cli.cmd_mcp(args), 1)
+
+    def test_inventory_exposes_capture_tools(self) -> None:
+        inventory = site_tools.list_tools()
+
+        self.assertIn("web://web-captures", inventory["resources"])
+        self.assertIn("web_capture_status", inventory["tools"])
+        self.assertIn("web_capture_render", inventory["tools"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/web_captures/test_render.py
+++ b/test/web_captures/test_render.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "web_captures" / "render.py"
+SPEC = importlib.util.spec_from_file_location("unaltraweb_web_captures", MODULE_PATH)
+assert SPEC and SPEC.loader
+captures = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(captures)
+
+PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+)
+
+
+def write_recipe(destination: Path, **overrides: object) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    recipe: dict[str, object] = {
+        "version": 1,
+        "path": "/manual/chapter/",
+        "viewport": {"width": 1280, "height": 720},
+        "theme": {
+            "setting": "cafe",
+            "expect": {"selector": "html", "attribute": "data-theme", "equals": "cafe"},
+        },
+        "waits": {"selectors": [".manual-content"]},
+        "annotations": [
+            {
+                "id": "chapter-nav",
+                "selector": ".manual-sidebar",
+                "kind": "arrow",
+                "text": "Chapter navigation",
+            }
+        ],
+    }
+    recipe.update(overrides)
+    destination.write_text(yaml.safe_dump(recipe, sort_keys=False), encoding="utf-8")
+
+
+class WebCaptureRendererTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.project = Path(self.temp.name).resolve()
+        self.source = self.project / "assets/captures/manual.capture.yml"
+        write_recipe(self.source)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_discovers_source_and_preserves_capture_basename(self) -> None:
+        records = captures.discover(self.project)
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["source_path"], "assets/captures/manual.capture.yml")
+        self.assertEqual(captures.relative(self.project, records[0]["png"]), "assets/captures/manual.capture.png")
+        self.assertEqual(captures.relative(self.project, records[0]["svg"]), "assets/captures/manual.capture.svg")
+        self.assertEqual(captures.relative(self.project, records[0]["edited"]), "assets/captures/manual.capture.edited.svg")
+
+    def test_rejects_remote_recipe_url(self) -> None:
+        write_recipe(self.source, path="https://example.com/manual/")
+
+        with self.assertRaisesRegex(captures.WebCaptureError, "local absolute URL path"):
+            captures.discover(self.project)
+
+    def test_rejects_unknown_recipe_keys_and_script_like_selectors(self) -> None:
+        write_recipe(self.source, script="alert(1)")
+        with self.assertRaisesRegex(captures.WebCaptureError, "Unknown capture recipe keys"):
+            captures.discover(self.project)
+
+        write_recipe(self.source, annotations=[{"selector": "main\nscript", "kind": "outline"}])
+        with self.assertRaisesRegex(captures.WebCaptureError, "CSS selector"):
+            captures.discover(self.project)
+
+    def test_rejects_mutually_exclusive_capture_modes(self) -> None:
+        write_recipe(self.source, capture={"full_page": True, "selector": "main"})
+
+        with self.assertRaisesRegex(captures.WebCaptureError, "mutually exclusive"):
+            captures.discover(self.project)
+
+    def test_clip_padding_is_preserved(self) -> None:
+        write_recipe(self.source, capture={"clip": {"selector": "main", "padding": 24}})
+
+        record = captures.discover(self.project)[0]
+
+        self.assertEqual(record["recipe"]["capture"]["clip"], {"selector": "main", "padding": 24})
+
+    def test_selected_source_cannot_escape_project(self) -> None:
+        with self.assertRaisesRegex(captures.WebCaptureError, "safe project-relative"):
+            captures.status(self.project, source="../outside.capture.yml")
+
+    def test_svg_embeds_original_png_and_vector_layers(self) -> None:
+        record = captures.discover(self.project)[0]
+        png = self.project / "tmp.png"
+        png.write_bytes(PNG_1X1)
+        worker = {
+            "browser_version": "123.0",
+            "device_scale_factor": 1,
+            "origin": {"x": 0, "y": 0},
+            "annotations": [
+                {
+                    **record["recipe"]["annotations"][0],
+                    "box": {"x": 0, "y": 0, "width": 1, "height": 1},
+                }
+            ],
+        }
+
+        rendered = captures.svg_for(self.project, record, png, worker, "fingerprint")
+
+        self.assertIn(base64.b64encode(PNG_1X1).decode("ascii"), rendered)
+        self.assertIn('inkscape:label="Background"', rendered)
+        self.assertIn('inkscape:label="Highlights"', rendered)
+        self.assertIn('inkscape:label="Arrows"', rendered)
+        self.assertIn('inkscape:label="Labels"', rendered)
+        self.assertIn('id="annotation-chapter-nav"', rendered)
+        self.assertIn("Chapter navigation", rendered)
+        metadata_match = captures.SVG_METADATA_RE.search(rendered)
+        self.assertIsNotNone(metadata_match)
+
+    @patch.object(captures, "inspect_image", return_value={"available": "false", "id": "", "digest": ""})
+    def test_status_detects_current_outputs_and_stale_edited_override(self, _inspect_image) -> None:
+        record = captures.discover(self.project)[0]
+        record["png"].write_bytes(PNG_1X1)
+        record["svg"].write_text("<svg/>", encoding="utf-8")
+        fingerprint, dependencies, image = captures.fingerprint(self.project, record)
+        captures.write_lock(
+            self.project,
+            {
+                "records": {
+                    record["source_path"]: {
+                        "fingerprint": fingerprint,
+                        "dependencies": dependencies,
+                        "image": image["image"],
+                        "png": {"path": captures.relative(self.project, record["png"]), **captures.file_signature(record["png"])},
+                        "svg": {"path": captures.relative(self.project, record["svg"]), **captures.file_signature(record["svg"])},
+                    }
+                }
+            },
+        )
+
+        self.assertTrue(captures.status(self.project)["ok"])
+        stale_metadata = json.dumps({"png_sha256": "old", "fingerprint": fingerprint})
+        record["edited"].write_text(f'<svg><metadata id="unaltraweb-capture">{stale_metadata}</metadata></svg>', encoding="utf-8")
+        result = captures.status(self.project)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["captures"][0]["reason"], "edited_override_stale")
+
+    @patch.object(captures, "inspect_image", return_value={"available": "false", "id": "", "digest": ""})
+    def test_edited_override_must_match_current_fingerprint(self, _inspect_image) -> None:
+        record = captures.discover(self.project)[0]
+        record["png"].write_bytes(PNG_1X1)
+        record["svg"].write_text("<svg/>", encoding="utf-8")
+        fingerprint, dependencies, image = captures.fingerprint(self.project, record)
+        metadata = json.dumps({"png_sha256": captures.file_signature(record["png"])["sha256"], "fingerprint": "old"})
+        record["edited"].write_text(f'<svg><metadata id="unaltraweb-capture">{metadata}</metadata></svg>', encoding="utf-8")
+        captures.write_lock(
+            self.project,
+            {"records": {record["source_path"]: {"fingerprint": fingerprint, "dependencies": dependencies, "image": image["image"], "png": captures.file_signature(record["png"]), "svg": captures.file_signature(record["svg"])}}},
+        )
+
+        result = captures.status(self.project)
+
+        self.assertEqual(result["captures"][0]["reason"], "edited_override_stale")
+
+    def test_status_rejects_orphaned_capture_artifacts(self) -> None:
+        orphan = self.project / "assets/captures/old.capture.svg"
+        orphan.write_text("<svg/>", encoding="utf-8")
+
+        result = captures.status(self.project)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["orphaned_artifacts"], ["assets/captures/old.capture.svg"])
+
+    def test_first_publish_refuses_unmanaged_output(self) -> None:
+        record = captures.discover(self.project)[0]
+        record["svg"].write_text("author content", encoding="utf-8")
+        temporary = self.project / "capture.png"
+        temporary.write_bytes(PNG_1X1)
+
+        with self.assertRaisesRegex(captures.WebCaptureError, "unmanaged"):
+            captures.publish(record, temporary, "<svg/>", confirm_overwrite=False, owned=False)
+
+    def test_svg_safety_rejects_scripts_and_external_images(self) -> None:
+        unsafe = self.project / "unsafe.svg"
+        for text in [
+            "<svg><script>alert(1)</script></svg>",
+            '<svg><image href="https://example.com/x.png"/></svg>',
+            '<svg><style>@import url("https://example.com/x.css");</style></svg>',
+            '<svg><rect style="fill:url(https://example.com/x.svg)"/></svg>',
+            '<svg xml:base="https://example.com/"><use href="#shape"/></svg>',
+            '<svg><animate attributeName="href" to="https://example.com/x.svg"/></svg>',
+        ]:
+            with self.subTest(text=text):
+                unsafe.write_text(text, encoding="utf-8")
+                with self.assertRaises(captures.WebCaptureError):
+                    captures.validate_svg_safety(unsafe)
+
+    def test_base_url_is_an_origin_only(self) -> None:
+        with patch.dict("os.environ", {"WEB_CAPTURE_DOCKER_NETWORK": "capture-net", "WEB_CAPTURE_SERVICE_HOST": "capture-site"}), patch.object(captures, "internal_network", return_value=True):
+            self.assertEqual(captures.validate_base_url("http://capture-site:4000/"), "http://capture-site:4000")
+        for value in ["file:///tmp/site", "http://user:pass@localhost:4000", "http://localhost:4000/path", "https://example.com"]:
+            with self.subTest(value=value), self.assertRaises(captures.WebCaptureError):
+                captures.validate_base_url(value)
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/docker")
+    def test_internal_network_must_be_marked_internal(self, _which, run) -> None:
+        run.return_value.returncode = 0
+        run.return_value.stdout = "false\n"
+        self.assertFalse(captures.internal_network("ordinary-bridge"))
+
+        run.return_value.stdout = "true\n"
+        self.assertTrue(captures.internal_network("capture-net"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a reproducible web capture pipeline for selected page elements.
- Expose capture support through docs, MCP metadata, PDF integration, and tests.
- Add Docker/browser tooling for deterministic capture generation.

## Validation
- Existing branch tests cover capture rendering and MCP exposure.