### PR TITLE
Add production MCP distribution gates

### DIFF
--- a/.github/workflows/broken-links-site.yml
+++ b/.github/workflows/broken-links-site.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Build docs
         uses: actions/jekyll-build-pages@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,131 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install test package
+        run: python -m pip install -e ".[mcp]"
+
+      - name: Compile Python
+        run: python -m compileall -q src scripts test
+
+      - name: Run unit tests
+        run: PYTHONPATH=src python -m unittest discover -s test -p 'test_*.py'
+
+      - name: Check patch whitespace
+        run: git diff --check
+
+  distribution:
+    name: Distribution structure and wheel
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install build package
+        run: python -m pip install "setuptools>=68" wheel -e .
+
+      - name: Validate workflow policy
+        run: make workflow-check
+
+      - name: Validate distribution structure
+        run: make distribution-check
+
+      - name: Build and test wheel
+        run: make wheel-check
+
+  gem:
+    name: Gem package
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
+        with:
+          ruby-version: "3.3.5"
+
+      - name: Build and inspect gem
+        run: make gem-check
+
+  docker:
+    name: Docker MCP and docs
+    needs: [python, distribution, gem]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build runtime image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          load: true
+          push: false
+          tags: unaltraweb-runtime:ci
+          cache-from: type=gha,scope=ci-runtime
+          cache-to: type=gha,mode=max,scope=ci-runtime
+
+      - name: Build MCP image from the tested runtime
+        run: docker build --build-arg UNALTRAWEB_RUNTIME_IMAGE=unaltraweb-runtime:ci -t unaltraweb-mcp:ci -f Dockerfile.mcp .
+
+      - name: Smoke test MCP
+        run: make mcp-smoke-prebuilt MCP_IMAGE=unaltraweb-mcp:ci
+
+      - name: Build docs
+        run: make docs-build DOCKER_IMAGE=unaltraweb-runtime:ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,89 +1,46 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL Advanced"
+name: CodeQL
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 4 * * 2"
   workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
-
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - language: javascript-typescript
-            build-mode: none
-          - language: ruby
-            build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+        language: [javascript-typescript, python, ruby]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
+          build-mode: none
 
-          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-          # queries: security-extended,security-and-quality
-
-      # If the analyze step fails for one of the languages you are analyzing with
-      # "We were unable to automatically build your code", modify the matrix above
-      # to set the build mode to "manual" for that language. Then modify this step
-      # to build your code.
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-      - if: matrix.build-mode == 'manual'
-        shell: bash
-        run: |
-          echo 'If you are using a "manual" build mode for one or more of the' \
-            'languages you are analyzing, replace this with the commands to build' \
-            'your code, for example:'
-          echo '  make bootstrap'
-          echo '  make release'
-          exit 1
-
-      - name: Perform CodeQL Analysis
+      - name: Analyze
         uses: github/codeql-action/analyze@v3
         with:
-          category: "/language:${{matrix.language}}"
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/compute-images.yml
+++ b/.github/workflows/compute-images.yml
@@ -5,12 +5,51 @@ on:
 
 permissions:
   contents: read
-  packages: write
+
+concurrency:
+  group: publish-compute-images-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  build:
+  preflight:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install test package
+        run: python -m pip install -e .
+
+      - name: Require release-ready distribution
+        run: make distribution-release-check
+
+      - name: Validate publish ref and versions
+        env:
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: python scripts/validate_distribution.py --validate-publish-ref --components compute_python,compute_r
+
+      - name: Compile and test computation controller
+        run: |
+          python -m compileall -q scripts/computations
+          PYTHONPATH=src python -m unittest discover -s test/computations -p 'test_*.py'
+          PYTHONPATH=src python -m unittest discover -s test -p 'test_mcp_manual_computations.py'
+
+  build:
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
     strategy:
+      fail-fast: false
       matrix:
         include:
           - engine: python
@@ -22,16 +61,46 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - name: Build without publishing
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: false
+          cache-from: type=gha,scope=compute-${{ matrix.engine }}
+          cache-to: type=gha,mode=max,scope=compute-${{ matrix.engine }}
+
+  publish:
+    needs: [preflight, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - engine: python
+            image: unaltraweb-compute-python
+            dockerfile: scripts/computations/python/Dockerfile
+          - engine: r
+            image: unaltraweb-compute-r
+            dockerfile: scripts/computations/r/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Docker metadata
         id: meta
@@ -41,7 +110,15 @@ jobs:
           tags: |
             type=raw,value=main,enable={{is_default_branch}}
             type=sha,prefix=sha-
+            type=semver,pattern={{version}}
             type=ref,event=tag
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -53,3 +130,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=compute-${{ matrix.engine }}
           cache-to: type=gha,mode=max,scope=compute-${{ matrix.engine }}
+          sbom: true
+          provenance: mode=max

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,13 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         env:
           BUNDLE_GEMFILE: docs/Gemfile
         with:
@@ -39,7 +41,7 @@ jobs:
           bundle exec jekyll build --source docs --destination ./_site --config "$core_config,docs/_config.yml"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: ./_site
 
@@ -53,4 +55,4 @@ jobs:
     steps:
       - name: Deploy Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,43 +1,108 @@
-name: Docker image
+name: Docker images
 
 on:
   workflow_dispatch:
 
 permissions:
   contents: read
-  packages: write
+
+concurrency:
+  group: publish-core-images-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  build:
+  preflight:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
+        with:
+          ruby-version: "3.3.5"
+
+      - name: Install test package
+        run: python -m pip install "setuptools>=68" wheel -e ".[mcp]"
+
+      - name: Require release-ready distribution
+        run: make distribution-release-check
+
+      - name: Validate publish ref and versions
+        env:
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: python scripts/validate_distribution.py --validate-publish-ref --components runtime,mcp,manual_pdf
+
+      - name: Run package and source tests
+        run: |
+          python -m compileall -q src scripts test
+          PYTHONPATH=src python -m unittest discover -s test -p 'test_*.py'
+          make wheel-check
+          make gem-check
+          git diff --check
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - name: Validate publish ref
-        run: |
-          if test "$GITHUB_REF_TYPE" = "branch" && test "$GITHUB_REF_NAME" = "$GITHUB_DEFAULT_BRANCH"; then
-            exit 0
-          fi
-          if test "$GITHUB_REF_TYPE" = "tag" && printf '%s\n' "$GITHUB_REF_NAME" | grep -Eq '^v'; then
-            exit 0
-          fi
-          printf 'Run this workflow from %s or from a v* release tag.\n' "$GITHUB_DEFAULT_BRANCH" >&2
-          exit 1
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      - name: Build runtime without publishing
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          context: .
+          load: true
+          push: false
+          tags: unaltraweb-runtime:preflight
+          cache-from: type=gha,scope=core-runtime
+          cache-to: type=gha,mode=max,scope=core-runtime
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
+      - name: Build MCP without publishing
+        run: docker build --build-arg UNALTRAWEB_RUNTIME_IMAGE=unaltraweb-runtime:preflight -t unaltraweb-mcp:preflight -f Dockerfile.mcp .
+
+      - name: Build manual PDF image without publishing
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: scripts/manual
+          file: scripts/manual/Dockerfile
+          load: true
+          push: false
+          tags: unaltraweb-manual-pdf:preflight
+          cache-from: type=gha,scope=manual-pdf
+          cache-to: type=gha,mode=max,scope=manual-pdf
+
+      - name: Smoke test MCP
+        run: make mcp-smoke-prebuilt MCP_IMAGE=unaltraweb-mcp:preflight
+
+      - name: Build docs
+        run: make docs-build DOCKER_IMAGE=unaltraweb-runtime:preflight
+
+  publish:
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Runtime metadata
+        id: runtime-meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/dosquartsdedocs/unaltraweb
           tags: |
@@ -46,19 +111,9 @@ jobs:
             type=semver,pattern={{version}}
             type=ref,event=tag
 
-      - name: Build and publish
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: MCP Docker metadata
+      - name: MCP metadata
         id: mcp-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/dosquartsdedocs/unaltraweb-mcp
           tags: |
@@ -67,21 +122,9 @@ jobs:
             type=semver,pattern={{version}}
             type=ref,event=tag
 
-      - name: Build and publish MCP image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.mcp
-          build-args: UNALTRAWEB_RUNTIME_IMAGE=ghcr.io/dosquartsdedocs/unaltraweb:${{ steps.meta.outputs.version }}
-          push: true
-          tags: ${{ steps.mcp-meta.outputs.tags }}
-          labels: ${{ steps.mcp-meta.outputs.labels }}
-          cache-from: type=gha,scope=mcp
-          cache-to: type=gha,mode=max,scope=mcp
-
-      - name: Manual PDF Docker metadata
+      - name: Manual PDF metadata
         id: manual-meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/dosquartsdedocs/unaltraweb-manual-pdf
           tags: |
@@ -90,8 +133,42 @@ jobs:
             type=semver,pattern={{version}}
             type=ref,event=tag
 
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish runtime
+        id: runtime
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.runtime-meta.outputs.tags }}
+          labels: ${{ steps.runtime-meta.outputs.labels }}
+          cache-from: type=gha,scope=core-runtime
+          cache-to: type=gha,mode=max,scope=core-runtime
+          sbom: true
+          provenance: mode=max
+
+      - name: Build and publish MCP from runtime digest
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile.mcp
+          build-args: UNALTRAWEB_RUNTIME_IMAGE=ghcr.io/dosquartsdedocs/unaltraweb@${{ steps.runtime.outputs.digest }}
+          push: true
+          tags: ${{ steps.mcp-meta.outputs.tags }}
+          labels: ${{ steps.mcp-meta.outputs.labels }}
+          cache-from: type=gha,scope=mcp
+          cache-to: type=gha,mode=max,scope=mcp
+          sbom: true
+          provenance: mode=max
+
       - name: Build and publish manual PDF image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: scripts/manual
           file: scripts/manual/Dockerfile
@@ -100,3 +177,5 @@ jobs:
           labels: ${{ steps.manual-meta.outputs.labels }}
           cache-from: type=gha,scope=manual-pdf
           cache-to: type=gha,mode=max,scope=manual-pdf
+          sbom: true
+          provenance: mode=max

--- a/.github/workflows/metrics-update.yml
+++ b/.github/workflows/metrics-update.yml
@@ -85,10 +85,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: ${{ inputs.ruby_version || '3.3.5' }}
           bundler-cache: true
@@ -104,7 +106,7 @@ jobs:
           printf 'core_dir=%s\n' "$core_dir" >> "$GITHUB_OUTPUT"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ inputs.python_version || '3.13' }}
           cache: pip
@@ -146,7 +148,7 @@ jobs:
 
       - name: Upload diagnostics
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: publication-metrics-diagnostics
           if-no-files-found: ignore

--- a/.github/workflows/package-prepare.yml
+++ b/.github/workflows/package-prepare.yml
@@ -1,0 +1,75 @@
+name: Prepare package candidates
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-prepare-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
+        with:
+          ruby-version: "3.3.5"
+
+      - name: Install package build dependencies
+        run: python -m pip install "setuptools>=68" wheel -e .
+
+      - name: Require release-ready distribution
+        run: make distribution-release-check
+
+      - name: Validate preparation ref and version
+        env:
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: python scripts/validate_distribution.py --validate-publish-ref --components gem,wheel
+
+      - name: Check package contracts
+        run: |
+          make wheel-check
+          make gem-check
+
+      - name: Read release version
+        id: version
+        run: |
+          version="$(python -c 'from unaltraweb_mcp import __version__; print(__version__)')"
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build immutable candidates and checksums
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          mkdir -p dist/release
+          PIP_NO_INDEX=1 python -m pip wheel . --no-deps --no-build-isolation --wheel-dir dist/release
+          gem build unaltraweb.gemspec --output "dist/release/unaltraweb-${VERSION}.gem"
+          cd dist/release
+          sha256sum ./*.gem ./*.whl > SHA256SUMS
+
+      - name: Upload package candidates
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: unaltraweb-${{ steps.version.outputs.version }}-${{ github.sha }}
+          path: dist/release/
+          if-no-files-found: error
+          compression-level: 0
+          overwrite: false
+          retention-days: 14

--- a/.github/workflows/project-compute-image.yml
+++ b/.github/workflows/project-compute-image.yml
@@ -21,30 +21,128 @@ on:
         type: string
         default: .
       base_image:
-        description: Base computation image passed as BASE_IMAGE.
+        description: Digest-pinned base computation image passed as BASE_IMAGE.
         required: true
         type: string
+      test_command:
+        description: Optional project test command run before the image build.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
-  packages: write
+
+concurrency:
+  group: publish-project-compute-${{ github.repository }}-${{ github.ref }}-${{ inputs.engine }}
+  cancel-in-progress: false
 
 jobs:
-  build:
+  preflight:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
-      - name: Checkout
+      - name: Checkout workflow release gate
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: dosquartsdedocs/unaltraweb
+          ref: ${{ github.workflow_sha }}
+          path: release-gate
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: release-gate/pyproject.toml
+
+      - name: Install release gate dependencies
+        run: python -m pip install -e ./release-gate
+
+      - name: Require release-ready core distribution
+        run: make -C release-gate distribution-release-check
+
+      - name: Checkout project
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          path: project
+          persist-credentials: false
+
+      - name: Validate inputs and publish ref
+        env:
+          BASE_IMAGE: ${{ inputs.base_image }}
+          BUILD_CONTEXT: ${{ inputs.context }}
+          DOCKERFILE: ${{ inputs.dockerfile }}
+          ENGINE: ${{ inputs.engine }}
+          IMAGE: ${{ inputs.image }}
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import PurePosixPath
+
+          errors = []
+          if not re.fullmatch(r"[a-z0-9][a-z0-9._-]*", os.environ["ENGINE"]):
+              errors.append("engine must be a lowercase Docker-safe identifier")
+          if not re.fullmatch(r"[a-z0-9][a-z0-9._-]*", os.environ["IMAGE"]):
+              errors.append("image must be a lowercase GHCR package name")
+          if not re.fullmatch(r"[^\s@]+@sha256:[0-9a-f]{64}", os.environ["BASE_IMAGE"]):
+              errors.append("base_image must use an exact sha256 digest")
+          for label, value in [("context", os.environ["BUILD_CONTEXT"]), ("dockerfile", os.environ["DOCKERFILE"])]:
+              path = PurePosixPath(value)
+              if not value or path.is_absolute() or ".." in path.parts:
+                  errors.append(f"{label} must be a confined project-relative path")
+          ref_type = os.environ.get("GITHUB_REF_TYPE", "")
+          ref_name = os.environ.get("GITHUB_REF_NAME", "")
+          default_branch = os.environ.get("GITHUB_DEFAULT_BRANCH", "")
+          if not (
+              (ref_type == "branch" and ref_name == default_branch and default_branch)
+              or (ref_type == "tag" and re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", ref_name))
+          ):
+              errors.append("run from the default branch or an exact vX.Y.Z tag")
+          if errors:
+              raise SystemExit("\n".join(errors))
+          PY
+
+      - name: Run project tests
+        if: ${{ inputs.test_command != '' }}
+        working-directory: project
+        env:
+          TEST_COMMAND: ${{ inputs.test_command }}
+        run: bash -euo pipefail -c "$TEST_COMMAND"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - name: Build without publishing
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          context: project/${{ inputs.context }}
+          file: project/${{ inputs.dockerfile }}
+          build-args: |
+            BASE_IMAGE=${{ inputs.base_image }}
+          push: false
+          cache-from: type=gha,scope=project-compute-${{ inputs.engine }}
+          cache-to: type=gha,mode=max,scope=project-compute-${{ inputs.engine }}
+
+  publish:
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          path: project
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Docker metadata
         id: meta
@@ -54,13 +152,21 @@ jobs:
           tags: |
             type=raw,value=main,enable={{is_default_branch}}
             type=sha,prefix=sha-
+            type=semver,pattern={{version}}
             type=ref,event=tag
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          context: ${{ inputs.context }}
-          file: ${{ inputs.dockerfile }}
+          context: project/${{ inputs.context }}
+          file: project/${{ inputs.dockerfile }}
           build-args: |
             BASE_IMAGE=${{ inputs.base_image }}
           push: true
@@ -68,3 +174,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=project-compute-${{ inputs.engine }}
           cache-to: type=gha,mode=max,scope=project-compute-${{ inputs.engine }}
+          sbom: true
+          provenance: mode=max

--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -75,6 +75,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1

--- a/.github/workflows/web-capture-image.yml
+++ b/.github/workflows/web-capture-image.yml
@@ -5,24 +5,72 @@ on:
 
 permissions:
   contents: read
-  packages: write
+
+concurrency:
+  group: publish-web-capture-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  build:
+  preflight:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install test package
+        run: python -m pip install -e .
+
+      - name: Require release-ready distribution
+        run: make distribution-release-check
+
+      - name: Validate publish ref and version
+        env:
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: python scripts/validate_distribution.py --validate-publish-ref --components web_capture
+
+      - name: Compile and test web capture controller
+        run: |
+          python -m compileall -q scripts/web_captures
+          PYTHONPATH=src python -m unittest discover -s test/web_captures -p 'test_*.py'
+          PYTHONPATH=src python -m unittest discover -s test -p 'test_mcp_web_captures.py'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - name: Build without publishing
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          context: .
+          file: scripts/web_captures/Dockerfile
+          push: false
+          cache-from: type=gha,scope=web-capture
+          cache-to: type=gha,mode=max,scope=web-capture
+
+  publish:
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Docker metadata
         id: meta
@@ -32,7 +80,15 @@ jobs:
           tags: |
             type=raw,value=main,enable={{is_default_branch}}
             type=sha,prefix=sha-
+            type=semver,pattern={{version}}
             type=ref,event=tag
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -44,3 +100,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=web-capture
           cache-to: type=gha,mode=max,scope=web-capture
+          sbom: true
+          provenance: mode=max

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -1,4 +1,4 @@
-ARG UNALTRAWEB_RUNTIME_IMAGE=unaltraweb/runtime:latest
+ARG UNALTRAWEB_RUNTIME_IMAGE=ghcr.io/dosquartsdedocs/unaltraweb:0.3.0
 FROM ${UNALTRAWEB_RUNTIME_IMAGE}
 
 LABEL org.opencontainers.image.source="https://github.com/dosquartsdedocs/unaltraweb"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,16 @@ Create a clean profile-specific repository locally or through the MCP:
 unaltraweb-mcp --project ./my-site new-web --site-profile unaltredocs --title "Project documentation" --default-lang en
 ```
 
-The command is idempotent for identical inputs and refuses differing files, symlinks, and unsafe language paths. It does not require or inspect `unaltraweb-template`.
+The command is idempotent for identical inputs and refuses differing files, symlinks, and unsafe language paths. It records the five package-managed runtime files in `.unaltraweb/scaffold.json`; an explicit `scaffold_sync` dry-run can later update only files that remain unchanged from that baseline. It does not require or inspect `unaltraweb-template`.
+
+The wheel can verify its own modular distribution and a generated site without a factory checkout:
+
+```bash
+unaltraweb-mcp doctor
+unaltraweb-mcp doctor --project ./my-site
+```
+
+Add `--docker` only when local presence of the selected feature images should be inspected. Doctor never pulls images. Factory-backed build, computation, capture, PDF, bibliometrics, prompt, and MCP serve commands require `UNALTRAWEB_FACTORY_DIR` or the published MCP container.
 
 ### GitHub-only
 
@@ -36,7 +45,7 @@ make test
 make down
 ```
 
-These targets run through the pinned MCP Docker image; Ruby and Bundler are not required on the host. The native targets remain available inside the MCP runtime. Layouts, styles and plugins still come from the `unaltraweb` gem/core mounted in that image.
+These targets run through the pinned MCP Docker image; Ruby and Bundler are not required on the host. `make test` also audits generated HTML links, fragments, IDs, Liquid residue, image alt attributes, title, and language without fetching external URLs. The native targets remain available inside the MCP runtime. Layouts, styles and plugins still come from the `unaltraweb` gem/core mounted in that image.
 
 When running the core documentation and all template profiles together, use the convention `4000` for `unaltraweb` and `4001` through `4004` for `unaltreselfie`, `unaltreprojecte`, `unaltremanual` and `unaltredocs`.
 
@@ -78,9 +87,9 @@ This core repository publishes its own `unaltraweb` reference site from `docs/` 
 The reference site uses the real `unaltredocs` profile from the local `unaltraweb` gem:
 
 ```bash
-make docs-serve DOCKER_IMAGE=unaltraweb:local
-make docs-build DOCKER_IMAGE=unaltraweb:local
-make docs-publish DOCKER_IMAGE=unaltraweb:local
+make docs-serve DOCKER_IMAGE=unaltraweb:dev
+make docs-build DOCKER_IMAGE=unaltraweb:dev
+make docs-publish DOCKER_IMAGE=unaltraweb:dev
 ```
 
 Publication metrics are intentionally separate from automatic deploys. Run them locally or through the manual/reusable `.github/workflows/metrics-update.yml` workflow.

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ COMPUTE_CONFIRM_OVERWRITE ?= 0
 COMPUTE_STALE_ONLY ?= 0
 COMPUTE_MODE ?=
 COMPUTE_SCRIPT := $(CURDIR)/scripts/computations/render.py
-COMPUTE_PYTHON_LOCAL_IMAGE ?= unaltraweb-compute-python:local
-COMPUTE_R_LOCAL_IMAGE ?= unaltraweb-compute-r:local
+COMPUTE_PYTHON_LOCAL_IMAGE ?= unaltraweb-compute-python:dev
+COMPUTE_R_LOCAL_IMAGE ?= unaltraweb-compute-r:dev
 COMPUTE_DOCKER_BUILD_NETWORK ?= default
 COMPUTE_CPUS ?= 4
 COMPUTE_MEMORY ?= 8g
@@ -34,15 +34,21 @@ WEB_CAPTURE_DOCKER_NETWORK ?=
 WEB_CAPTURE_SERVICE_HOST ?=
 WEB_CAPTURE_CONFIRM_OVERWRITE ?= 0
 WEB_CAPTURE_SCRIPT := $(CURDIR)/scripts/web_captures/render.py
-WEB_CAPTURE_IMAGE ?= ghcr.io/dosquartsdedocs/unaltraweb-web-capture:main
+WEB_CAPTURE_IMAGE ?= ghcr.io/dosquartsdedocs/unaltraweb-web-capture:0.3.0
+WEB_CAPTURE_DEV_IMAGE ?= unaltraweb-web-capture:dev
 WEB_CAPTURE_DOCKER_BUILD_NETWORK ?= default
 VEGAVISUALS_PATH ?= $(PROJECT_ROOT)/../vegavisuals
 VEGAVISUALS_ROOT := $(shell realpath -m -- "$(VEGAVISUALS_PATH)")
 VEGAVISUALS_CLI ?=
-DOCKER_IMAGE ?= ghcr.io/dosquartsdedocs/unaltraweb:main
-MANUAL_PDF_IMAGE ?= unaltraweb-manual-pdf:local
+DOCKER_IMAGE ?= ghcr.io/dosquartsdedocs/unaltraweb:0.3.0
+MANUAL_PDF_IMAGE ?= ghcr.io/dosquartsdedocs/unaltraweb-manual-pdf:0.3.0
+MANUAL_PDF_DEV_IMAGE ?= unaltraweb-manual-pdf:dev
 MANUAL_PDF_LANG ?=
 MANUAL_PDF_PUBLISH_DRY_RUN ?= 1
+UNALTRAWEB_WORKER_ROLE ?=
+UNALTRAWEB_WORKER_PROJECT ?=
+UNALTRAWEB_WORKER_TOKEN ?=
+WORKER_LABEL_ARGS = $(if $(strip $(UNALTRAWEB_WORKER_TOKEN)),--label "io.context.mcp-factory=unaltraweb" --label "io.context.mcp-role=$(UNALTRAWEB_WORKER_ROLE)" --label "io.context.mcp-project=$(UNALTRAWEB_WORKER_PROJECT)" --label "io.context.mcp-worker-token=$(UNALTRAWEB_WORKER_TOKEN)",)
 DOCS_CONTAINER ?= unaltraweb-docs-local
 DOCS_HOST ?= 0.0.0.0
 DOCS_PORT ?= 4000
@@ -58,8 +64,26 @@ ifneq ($(strip $(SCIMAGO_INPUT)),)
 SCIMAGO_ARGS += --input "$(SCIMAGO_INPUT)"
 endif
 
-.PHONY: docs-build docs-serve docs-publish docs-down metrics-scimago-fetch metrics-update metrics-update-all metrics-check manual-pdf-image manual-pdf-status manual-pdf-check manual-pdf-build manual-pdf-publish manual-pdf-sync manual-compute-status manual-compute-check manual-compute-render manual-compute-render-figures manual-compute-image-python manual-compute-image-r manual-compute-images manual-compute-rstudio compute-base-image-python compute-base-image-r web-capture-status web-capture-check web-capture-render web-capture-image visualization-status visualization-check visualization-render
-.PHONY: mcp-runtime-image mcp-image mcp-build mcp-init mcp-check mcp-smoke mcp-stdio mcp-down mcp-list-tools mcp-starter-templates mcp-new-web mcp-initialize-site mcp-site-context mcp-profile-check mcp-manual-source-quality-check mcp-manual-editorial-quality-check mcp-manual-authoring-capabilities mcp-manual-computation-status mcp-manual-computation-check mcp-manual-computation-render mcp-manual-computation-render-figures mcp-web-capture-status mcp-web-capture-check mcp-web-capture-render mcp-manual-pdf-status mcp-manual-pdf-build mcp-manual-pdf-publish mcp-profile-prune-plan mcp-profile-prune mcp-content-inventory mcp-language-policy mcp-content-approval-inventory mcp-translation-plan mcp-bibliography-inventory mcp-bibliometrics-check mcp-build-health
+.PHONY: distribution-check distribution-release-check distribution-doctor workflow-check wheel-check gem-check docs-build docs-serve docs-publish docs-down metrics-scimago-fetch metrics-update metrics-update-all metrics-check manual-pdf-image manual-pdf-image-dev manual-pdf-preflight manual-pdf-status manual-pdf-check manual-pdf-build manual-pdf-publish manual-pdf-sync manual-compute-status manual-compute-check manual-compute-render manual-compute-render-figures manual-compute-image-python manual-compute-image-r manual-compute-images manual-compute-rstudio compute-base-image-python compute-base-image-r web-capture-status web-capture-check web-capture-render web-capture-image visualization-status visualization-check visualization-render
+.PHONY: mcp-runtime-image mcp-image mcp-build mcp-check mcp-smoke mcp-smoke-prebuilt mcp-stdio mcp-down mcp-down-all mcp-list-tools mcp-starter-templates mcp-new-web mcp-initialize-site mcp-site-context mcp-profile-check mcp-manual-source-quality-check mcp-manual-editorial-quality-check mcp-manual-authoring-capabilities mcp-manual-computation-status mcp-manual-computation-check mcp-manual-computation-render mcp-manual-computation-render-figures mcp-web-capture-status mcp-web-capture-check mcp-web-capture-render mcp-manual-pdf-status mcp-manual-pdf-build mcp-manual-pdf-publish mcp-profile-prune-plan mcp-profile-prune mcp-content-inventory mcp-language-policy mcp-content-approval-inventory mcp-translation-plan mcp-bibliography-inventory mcp-bibliometrics-check mcp-build-health
+
+distribution-check: ## Validate component/version parity, release selections, and the wheel boundary
+	@PYTHONPATH="$(CURDIR)/src" $(PYTHON) scripts/validate_distribution.py
+
+distribution-release-check: ## Require every selected component release to be published
+	@PYTHONPATH="$(CURDIR)/src" $(PYTHON) scripts/validate_distribution.py --require-release-ready
+
+distribution-doctor: ## Inspect the selected distribution and PROJECT without network access
+	@PYTHONPATH="$(CURDIR)/src" $(PYTHON) -m unaltraweb_mcp.cli doctor --project "$(PROJECT)"
+
+workflow-check: ## Validate GitHub Actions syntax and publication safety gates
+	@$(PYTHON) scripts/validate_workflows.py
+
+wheel-check: ## Build and exercise a clean factory-free wheel install
+	@$(PYTHON) scripts/test_wheel_install.py
+
+gem-check: ## Build the gem and verify its package-owned contract files
+	@$(PYTHON) scripts/test_gem_build.py
 
 mcp-runtime-image: ## Build the reusable Jekyll runtime used by the MCP
 	docker build --network "$(MCP_DOCKER_BUILD_NETWORK)" -t "$(MCP_RUNTIME_IMAGE)" .
@@ -69,12 +93,13 @@ mcp-image: mcp-runtime-image ## Build the Dockerized FastMCP control plane
 
 mcp-build: mcp-image ## Prepare the Docker images used by MCP sessions, builds, and previews
 
-mcp-init: mcp-build ## Initialize reusable MCP dependencies without starting services
-
 mcp-check: mcp-image ## Verify the Dockerized MCP CLI contract
 	docker run --rm --entrypoint unaltraweb-mcp "$(MCP_IMAGE)" version
 
-mcp-smoke: mcp-build ## Prove a real MCP stdio connection against a minimal website
+mcp-smoke: mcp-build ## Build and prove a real MCP stdio connection
+	@$(MAKE) --silent --no-print-directory mcp-smoke-prebuilt MCP_IMAGE="$(MCP_IMAGE)"
+
+mcp-smoke-prebuilt: ## Prove a real MCP stdio connection using the selected prebuilt MCP image
 	docker run --rm --user "$(LOCAL_UID):$(LOCAL_GID)" -e HOME=/tmp --entrypoint python3 "$(MCP_IMAGE)" /opt/unaltraweb/test/mcp_smoke.py
 	@mkdir -p "$(CURDIR)/tmp/mcp-preview-smoke"
 	@docker_socket="$${UNALTRAWEB_DOCKER_SOCKET:-/var/run/docker.sock}"; socket_group=$$(stat -c '%g' "$$docker_socket"); \
@@ -90,10 +115,17 @@ mcp-smoke: mcp-build ## Prove a real MCP stdio connection against a minimal webs
 mcp-stdio: ## Serve the current PROJECT through the Dockerized stdio MCP
 	@exec "$(CURDIR)/scripts/unaltraweb-mcp-bootstrap.sh" --image "$(MCP_IMAGE)"
 
-mcp-down: ## Remove only containers owned by this MCP factory
+mcp-down: ## Remove MCP resources owned by PROJECT
+	@project_id="$$(/bin/sh "$(CURDIR)/scripts/unaltraweb-mcp-project-id.sh" "$(PROJECT_ROOT)")" || exit $$?; \
+	containers="$$(docker ps -aq --filter "label=io.context.mcp-factory=unaltraweb" --filter "label=io.context.mcp-project=$$project_id")" || exit $$?; \
+	if [ -n "$$containers" ]; then docker rm -f $$containers || exit $$?; fi; \
+	networks="$$(docker network ls -q --filter "label=io.context.mcp-factory=unaltraweb" --filter "label=io.context.mcp-project=$$project_id")" || exit $$?; \
+	if [ -n "$$networks" ]; then docker network rm $$networks; fi
+
+mcp-down-all: ## Remove all MCP resources owned by this factory (maintainers only)
 	@containers="$$(docker ps -aq --filter "label=io.context.mcp-factory=unaltraweb")" || exit $$?; \
-	if [ -n "$$containers" ]; then docker rm -f $$containers; fi; \
-	networks="$$(docker network ls -q --filter "label=io.context.mcp-factory=unaltraweb" --filter "label=io.context.mcp-role=web-capture")" || exit $$?; \
+	if [ -n "$$containers" ]; then docker rm -f $$containers || exit $$?; fi; \
+	networks="$$(docker network ls -q --filter "label=io.context.mcp-factory=unaltraweb")" || exit $$?; \
 	if [ -n "$$networks" ]; then docker network rm $$networks; fi
 
 mcp-list-tools: ## List MCP resources, prompts, and tools exposed by this factory
@@ -190,7 +222,7 @@ manual-compute-render: ## Execute sources and atomically publish Markdown and fi
 	@set -e; \
 	runtime_dir="$(PROJECT_ROOT)/tmp/.unaltraweb/computations"; \
 	mkdir -p "$$runtime_dir"; runtime_script=$$(mktemp "$$runtime_dir/render.XXXXXX"); cp "$(COMPUTE_SCRIPT)" "$$runtime_script"; \
-	results=$$(mktemp); trap 'rm -f "$$results" "$$runtime_script"' EXIT; \
+	results=$$(mktemp); cidfiles=""; trap 'rm -f "$$results" "$$runtime_script" $$cidfiles' EXIT; \
 	status=$$(COMPUTE_PYTHON_IMAGE="$(COMPUTE_PYTHON_IMAGE)" COMPUTE_R_IMAGE="$(COMPUTE_R_IMAGE)" $(PYTHON) "$(COMPUTE_SCRIPT)" status --project "$(PROJECT_ROOT)" $(if $(strip $(COMPUTE_SOURCE)),--source "$(COMPUTE_SOURCE)",) $(if $(strip $(COMPUTE_MODE)),--mode "$(COMPUTE_MODE)",)); \
 	engines=$$(printf '%s' "$$status" | $(PYTHON) -c 'import json,sys; data=json.load(sys.stdin); print(" ".join(f"{engine}={image}" for engine,image in sorted({(item["engine"], item["image"]["image"]) for item in data["sources"]})))'); \
 	for selection in $$engines; do \
@@ -202,7 +234,8 @@ manual-compute-render: ## Execute sources and atomically publish Markdown and fi
 	  fi; \
 	  identity=$$(docker image inspect "$$image" --format '{{.Id}}'); \
 	  digest=$$(docker image inspect "$$image" --format '{{join .RepoDigests ","}}'); \
-	  docker run --rm --user "$(LOCAL_UID):$(LOCAL_GID)" --network none --read-only --cap-drop ALL --security-opt no-new-privileges --pids-limit "$(COMPUTE_PIDS_LIMIT)" --cpus "$(COMPUTE_CPUS)" --memory "$(COMPUTE_MEMORY)" --tmpfs /tmp:rw,noexec,nosuid,size=1g \
+	  set --; if test -n "$(UNALTRAWEB_WORKER_TOKEN)"; then cidfile="$$runtime_dir/worker-$(UNALTRAWEB_WORKER_TOKEN)-$$engine.cid"; rm -f "$$cidfile"; cidfiles="$$cidfiles $$cidfile"; set -- --cidfile "$$cidfile"; fi; \
+	  docker run --rm "$$@" $(WORKER_LABEL_ARGS) --user "$(LOCAL_UID):$(LOCAL_GID)" --network none --read-only --cap-drop ALL --security-opt no-new-privileges --pids-limit "$(COMPUTE_PIDS_LIMIT)" --cpus "$(COMPUTE_CPUS)" --memory "$(COMPUTE_MEMORY)" --tmpfs /tmp:rw,noexec,nosuid,size=1g \
 	    -e HOME=/tmp -e COMPUTE_PYTHON_IMAGE="$$python_image" -e COMPUTE_R_IMAGE="$$r_image" \
 	    -e UNALTRAWEB_COMPUTE_IMAGE_ID="$$identity" -e UNALTRAWEB_COMPUTE_IMAGE_DIGEST="$$digest" \
 	    -v "$(PROJECT_ROOT):/project:rw" -v "$$runtime_script:/opt/unaltraweb/computations/render.py:ro" -w /project --entrypoint python3 "$$image" \
@@ -243,7 +276,7 @@ web-capture-render: ## Capture a trusted running preview and publish PNG plus an
 	@WEB_CAPTURE_IMAGE="$(WEB_CAPTURE_IMAGE)" WEB_CAPTURE_DOCKER_BUILD_NETWORK="$(WEB_CAPTURE_DOCKER_BUILD_NETWORK)" WEB_CAPTURE_DOCKER_NETWORK="$(WEB_CAPTURE_DOCKER_NETWORK)" WEB_CAPTURE_SERVICE_HOST="$(WEB_CAPTURE_SERVICE_HOST)" $(PYTHON) "$(WEB_CAPTURE_SCRIPT)" render --project "$(PROJECT_ROOT)" --base-url "$(WEB_CAPTURE_BASE_URL)" $(if $(strip $(WEB_CAPTURE_SOURCE)),--source "$(WEB_CAPTURE_SOURCE)",) $(if $(filter 1 true TRUE yes YES y Y,$(WEB_CAPTURE_CONFIRM_OVERWRITE)),--confirm-overwrite,)
 
 web-capture-image: ## Build the isolated Playwright web capture image
-	docker build --network "$(WEB_CAPTURE_DOCKER_BUILD_NETWORK)" -f scripts/web_captures/Dockerfile -t "$(WEB_CAPTURE_IMAGE)" .
+	docker build --network "$(WEB_CAPTURE_DOCKER_BUILD_NETWORK)" -f scripts/web_captures/Dockerfile -t "$(WEB_CAPTURE_DEV_IMAGE)" .
 
 define run_vegavisuals
 	@if test ! -f "$(PROJECT_ROOT)/.vegavisuals.yml"; then \
@@ -269,23 +302,38 @@ visualization-check: ## Reject stale Vega visualization outputs when configured
 visualization-render: ## Render missing or stale Vega visualizations when configured
 	$(call run_vegavisuals,render-all)
 
-manual-pdf-image: ## Build the isolated local Pandoc/XeLaTeX image
-	docker build -f scripts/manual/Dockerfile -t "$(MANUAL_PDF_IMAGE)" scripts/manual
+manual-pdf-image: ## Ensure the selected versioned Pandoc/XeLaTeX image is present
+	@docker image inspect "$(MANUAL_PDF_IMAGE)" >/dev/null 2>&1 || docker pull "$(MANUAL_PDF_IMAGE)"
 
-manual-pdf-status: manual-compute-check web-capture-check manual-pdf-image ## Inspect manual PDF configuration and artefacts
-	docker run --rm --user "$(LOCAL_UID):$(LOCAL_GID)" -e HOME=/tmp -v "$(PROJECT_ROOT):/project" -w /project "$(MANUAL_PDF_IMAGE)" status --project /project $(if $(strip $(MANUAL_PDF_LANG)),--language "$(MANUAL_PDF_LANG)",)
+manual-pdf-image-dev: ## Build the explicitly named maintainer PDF development image
+	docker build -f scripts/manual/Dockerfile -t "$(MANUAL_PDF_DEV_IMAGE)" scripts/manual
 
-manual-pdf-check: manual-compute-check web-capture-check manual-pdf-image ## Reject stale or unpublished manual PDF artefacts
-	docker run --rm --user "$(LOCAL_UID):$(LOCAL_GID)" -e HOME=/tmp -v "$(PROJECT_ROOT):/project" -w /project "$(MANUAL_PDF_IMAGE)" check --project /project $(if $(strip $(MANUAL_PDF_LANG)),--language "$(MANUAL_PDF_LANG)",)
+define run_manual_pdf_worker
+	@set -e; runtime_dir="$(PROJECT_ROOT)/tmp/.unaltraweb/manual-pdf"; mkdir -p "$$runtime_dir"; set --; cidfile=""; \
+	if test -n "$(UNALTRAWEB_WORKER_TOKEN)"; then cidfile="$$runtime_dir/worker-$(UNALTRAWEB_WORKER_TOKEN).cid"; rm -f "$$cidfile"; set -- --cidfile "$$cidfile"; fi; \
+	trap 'test -z "$$cidfile" || rm -f "$$cidfile"' EXIT; \
+	docker run --rm "$$@" $(WORKER_LABEL_ARGS) --user "$(LOCAL_UID):$(LOCAL_GID)" -e HOME=/tmp -v "$(PROJECT_ROOT):/project" -w /project "$(MANUAL_PDF_IMAGE)" $(1) --project /project $(if $(strip $(MANUAL_PDF_LANG)),--language "$(MANUAL_PDF_LANG)",) $(2)
+endef
 
-manual-pdf-build: manual-compute-check web-capture-check manual-pdf-image ## Build manual PDFs and cover previews under tmp
-	docker run --rm --user "$(LOCAL_UID):$(LOCAL_GID)" -e HOME=/tmp -v "$(PROJECT_ROOT):/project" -w /project "$(MANUAL_PDF_IMAGE)" build --project /project $(if $(strip $(MANUAL_PDF_LANG)),--language "$(MANUAL_PDF_LANG)",)
+manual-pdf-preflight: ## Run required PDF gates without contaminating the worker JSON stream
+	@$(MAKE) --silent --no-print-directory manual-compute-check PROJECT="$(PROJECT_ROOT)" >/dev/null
+	@$(MAKE) --silent --no-print-directory web-capture-check PROJECT="$(PROJECT_ROOT)" >/dev/null
+	@docker image inspect "$(MANUAL_PDF_IMAGE)" >/dev/null 2>&1 || docker pull "$(MANUAL_PDF_IMAGE)" >/dev/null
 
-manual-pdf-publish: manual-compute-check web-capture-check manual-pdf-image ## Copy built PDF artefacts to configured public paths
-	docker run --rm --user "$(LOCAL_UID):$(LOCAL_GID)" -e HOME=/tmp -v "$(PROJECT_ROOT):/project" -w /project "$(MANUAL_PDF_IMAGE)" publish --project /project $(if $(strip $(MANUAL_PDF_LANG)),--language "$(MANUAL_PDF_LANG)",) $(if $(filter 1 true TRUE yes YES y Y,$(MANUAL_PDF_PUBLISH_DRY_RUN)),--dry-run,)
+manual-pdf-status: manual-pdf-preflight ## Inspect manual PDF configuration and artefacts
+	$(call run_manual_pdf_worker,status)
 
-manual-pdf-sync: manual-compute-check web-capture-check manual-pdf-image ## Build and copy changed manual PDFs to their public paths
-	docker run --rm --user "$(LOCAL_UID):$(LOCAL_GID)" -e HOME=/tmp -v "$(PROJECT_ROOT):/project" -w /project "$(MANUAL_PDF_IMAGE)" sync --project /project $(if $(strip $(MANUAL_PDF_LANG)),--language "$(MANUAL_PDF_LANG)",)
+manual-pdf-check: manual-pdf-preflight ## Reject stale or unpublished manual PDF artefacts
+	$(call run_manual_pdf_worker,check)
+
+manual-pdf-build: manual-pdf-preflight ## Build manual PDFs and cover previews under tmp
+	$(call run_manual_pdf_worker,build)
+
+manual-pdf-publish: manual-pdf-preflight ## Copy built PDF artefacts to configured public paths
+	$(call run_manual_pdf_worker,publish,$(if $(filter 1 true TRUE yes YES y Y,$(MANUAL_PDF_PUBLISH_DRY_RUN)),--dry-run,))
+
+manual-pdf-sync: manual-pdf-preflight ## Build and copy changed manual PDFs to their public paths
+	$(call run_manual_pdf_worker,sync)
 
 docs-build: visualization-check
 	docker run --rm --user "$(LOCAL_UID):$(LOCAL_GID)" -e HOME=/tmp -e BUNDLE_GEMFILE=docs/Gemfile -e BUNDLE_APP_CONFIG=/work/tmp/docs_bundle_config -e BUNDLE_PATH=/work/tmp/docs_bundle_path -v "$(CURDIR):/work" -w /work $(DOCKER_IMAGE) bash -lc 'git config --global --add safe.directory /work >/dev/null 2>&1 || true; mkdir -p tmp/docs_bundle_config tmp/docs_bundle_path; bundle check || bundle install; core_config=$$(bundle exec ruby -e "spec = Gem::Specification.find_by_name(\"unaltraweb\"); print File.join(spec.full_gem_path, \"_config.yml\")"); bundle exec jekyll build --source docs --destination tmp/docs-site --config "$$core_config,docs/_config.yml" --disable-disk-cache'
@@ -301,12 +349,14 @@ docs-down:
 	-docker rm -f "$(DOCS_CONTAINER)" >/dev/null 2>&1 || true
 
 metrics-scimago-fetch:
-	@cd "$(PROJECT_ROOT)" && "$(CURDIR)/scripts/biblio/fetch_scimago_csv.sh" $(SCIMAGO_ARGS)
+	@cd "$(PROJECT_ROOT)" && "$(CURDIR)/scripts/biblio/fetch_scimago_csv.sh" $(SCIMAGO_ARGS) 1>&2 && $(PYTHON) -c 'import json; print(json.dumps({"ok": True, "project": "$(PROJECT_ROOT)", "scimago": ".cache/scimago/scimagojr.csv"}, indent=2))'
 
 metrics-update:
-	@cd "$(PROJECT_ROOT)" && $(PYTHON) "$(CURDIR)/scripts/biblio/metrics_update.py" $(METRICS_ARGS)
+	@cd "$(PROJECT_ROOT)" && $(PYTHON) "$(CURDIR)/scripts/biblio/metrics_update.py" $(METRICS_ARGS) 1>&2 && $(PYTHON) -c 'import json; print(json.dumps({"ok": True, "project": "$(PROJECT_ROOT)", "updated": True}, indent=2))'
 
-metrics-update-all: metrics-scimago-fetch metrics-update
+metrics-update-all:
+	@$(MAKE) --silent --no-print-directory metrics-scimago-fetch PROJECT="$(PROJECT_ROOT)" SCIMAGO_INPUT="$(SCIMAGO_INPUT)" 1>&2
+	@$(MAKE) --silent --no-print-directory metrics-update PROJECT="$(PROJECT_ROOT)" METRICS_ARGS="$(METRICS_ARGS)"
 
 metrics-check:
-	@cd "$(PROJECT_ROOT)" && $(PYTHON) "$(CURDIR)/scripts/biblio/metrics_update.py" --offline --dry-run $(METRICS_ARGS)
+	@cd "$(PROJECT_ROOT)" && $(PYTHON) "$(CURDIR)/scripts/biblio/metrics_update.py" --offline --dry-run $(METRICS_ARGS) 1>&2 && $(PYTHON) -c 'import json; print(json.dumps({"ok": True, "project": "$(PROJECT_ROOT)", "offline": True, "dry_run": True}, indent=2))'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It packages shared layouts, includes, Sass, assets, Jekyll plugins, bibliometric
 
 - The core builds successfully as a standalone Jekyll site through Docker.
 - The repository is packaged as the `unaltraweb` gem and publishes the shared Docker runtime image as `ghcr.io/dosquartsdedocs/unaltraweb`.
-- The MCP package and image contain profile-specific scaffolds for creating sites without another checkout.
+- The modular MCP wheel contains profile-specific scaffolds, the versioned component BOM, doctor, and local inspection; it does not bundle the gem, factory checkout, worker images, or companion renderers.
 - The companion `../unaltraweb-template` repository remains the full-profile integration fixture and visual demo.
 - The project is still pre-release. Some inherited `al-folio` implementation details remain while the core is being generalized.
 
@@ -58,7 +58,7 @@ From this factory checkout, the equivalent command is:
 make mcp-new-web PROJECT=./my-site NEW_WEB_PROFILE=unaltreselfie SITE_TITLE="My site" DEFAULT_LANG=en
 ```
 
-The operation uses only assets shipped in `unaltraweb_mcp`, preflights all managed paths, and never overwrites differing files. `dosquartsdedocs/unaltraweb-template` remains available when a full multi-profile demo with Playwright tests is more useful than a clean profile-specific site.
+The operation uses only assets shipped in `unaltraweb_mcp`, preflights all managed paths, writes `.unaltraweb/scaffold.json`, and never overwrites differing files. Later `scaffold_sync` calls can update only unchanged baseline runtime files and never touch config or content. `dosquartsdedocs/unaltraweb-template` remains available when a full multi-profile demo with Playwright tests is more useful than a clean profile-specific site.
 
 After creation, there are two supported editing paths:
 
@@ -89,15 +89,15 @@ docker compose -f docker-compose.yml down --remove-orphans
 Use the `unaltraweb` reference-site workflow when checking `docs/` through the real `unaltredocs` profile:
 
 ```bash
-make docs-serve DOCKER_IMAGE=unaltraweb:local
-make docs-build DOCKER_IMAGE=unaltraweb:local
+make docs-serve DOCKER_IMAGE=unaltraweb:dev
+make docs-build DOCKER_IMAGE=unaltraweb:dev
 ```
 
-The published runtime image is `ghcr.io/dosquartsdedocs/unaltraweb:main`. It replaces the inherited `al-folio` image for local template workflows while the gem remains the source of the theme code.
+The selected consumer runtime is `ghcr.io/dosquartsdedocs/unaltraweb:0.3.0`. The mutable `:main` channel is reserved for explicit maintainer testing; locally built core images use the `:dev` name. The gem remains the source of theme code.
 
 The independent manual PDF runtime is built from `scripts/manual/Dockerfile`; it is deliberately separate from the Jekyll image so normal site builds do not carry Pandoc and TeX Live.
 
-The GHCR image is a shared runtime, not the source of the theme. Publish it only through the manual Docker image workflow when runtime dependencies change.
+The GHCR image is a shared runtime, not the source of the theme. Publish it only through the manual Docker image workflow when runtime dependencies change. That workflow does not receive package-write permissions until its strict release preflight, source/package tests, image builds, MCP smoke test and docs build have all passed.
 
 When running the core and the template profiles together, keep `unaltraweb` on port `4000` and the template profile servers on `4001` through `4004`.
 
@@ -114,26 +114,47 @@ make down
 
 The template tests are intentionally heavier because they run browser smoke tests and screenshots. On constrained machines, prefer `make build` first and run Playwright only when needed.
 
+## Modular Wheel And Doctor
+
+The `unaltraweb-mcp` wheel is intentionally a small control and inspection package. A wheel-only install supports `version`, `new-web`, top-level `doctor`, constrained SHA-256 source edits, baseline-aware `scaffold_sync`, `site-doctor`, `html-audit`, and package-only inspections such as `detect-site`, `profile-check`, `content-inventory`, and `build-health`. Commands that execute factory Make targets or serve MCP require a factory checkout and fail with an explicit `UNALTRAWEB_FACTORY_DIR` remediation when it is absent.
+
+```bash
+unaltraweb-mcp version
+unaltraweb-mcp doctor
+unaltraweb-mcp doctor --project /path/to/site
+unaltraweb-mcp doctor --project /path/to/site --docker
+```
+
+Doctor is offline. The optional `--docker` mode only calls local Docker version/image inspection and never pulls. Its findings have stable `code`, `severity`, `expected`, `actual`, and `remediation` fields. `src/unaltraweb_mcp/component-contract.json` is the canonical release BOM; the adjacent versioned JSON Schema defines its machine-readable contract.
+
 ## Global Dockerized MCP
 
-`unaltraweb` provides one global, on-demand stdio MCP whose container is scoped to the current consumer workspace. The launcher pulls the pinned public image `ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0` when it is not available locally. To build and test the same image from this checkout instead:
+`unaltraweb` provides one global, on-demand stdio MCP whose containers are scoped to the current consumer workspace. Each client session gets an independent Docker-generated container name plus stable factory, role, and project labels, so concurrent sessions for the same project do not collide. The launcher pulls the pinned public image `ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0` when it is not available locally. To build and test the same image from this checkout instead:
 
 ```bash
 make mcp-build
 make mcp-smoke
 ```
 
-Register a global client command that preserves the workspace before `make -C` changes directory. For OpenCode, use the following `command` array and restart OpenCode after changing its configuration:
+ContExt reads the canonical manifest transport `make -C ${factoryRoot} mcp-stdio PROJECT=${workspaceFolder}`. For global Codex and OpenCode registration, the manager converts the workspace placeholder into a launch-time shell wrapper so `$PWD` is captured before `make -C` changes directory. The manifest itself continues to use `make`, an allowed container host launcher, and does not require a `runtime.allowed_host_launchers` exception. An equivalent OpenCode `command` array is:
 
 ```json
 [
   "/bin/sh",
   "-c",
-  "exec env PROJECT=\"$PWD\" make --silent --no-print-directory -C /path/to/unaltraweb mcp-stdio"
+  "workspace=$PWD; exec make --silent --no-print-directory -C /path/to/unaltraweb mcp-stdio PROJECT=\"$workspace\""
 ]
 ```
 
-Replace `/path/to/unaltraweb` with this checkout's absolute path. Do not use `PROJECT=.` in a global registration. Each session mounts its resolved project at `/workspace` and at its canonical host path, so Docker-backed authoring tools pass valid bind paths to the host daemon. `build_site` runs Jekyll directly in that MCP runtime. `preview_start`, `preview_status`, and `preview_stop` manage one labelled preview container per project, while `make mcp-down` removes only containers labelled `io.context.mcp-factory=unaltraweb`.
+Replace `/path/to/unaltraweb` with this checkout's absolute path and restart the client after changing its configuration. Do not use `PROJECT=.` after `make -C` in a global registration. Each session mounts its resolved project at `/workspace` and at its canonical host path, so Docker-backed authoring tools pass valid bind paths to the host daemon. `build_site` runs Jekyll directly in that MCP runtime and returns the offline HTML audit. `preview_start`, `preview_status`, and `preview_stop` manage one labelled preview container per project; `http_check` derives its origin only from that owned preview and never accepts an arbitrary URL.
+
+Dependency preparation builds images and required companions only; it does not initialize a consumer website, and companion `init` aggregation is disabled. Create a site explicitly with the `new_web` MCP tool. To clean up one consumer project, pass the same canonical project path used at launch:
+
+```bash
+make mcp-down PROJECT=/path/to/consumer
+```
+
+This selects only resources carrying both `io.context.mcp-factory=unaltraweb` and that project's stable `io.context.mcp-project` label. Maintainers can deliberately clean every labelled unaltraweb MCP resource with `make mcp-down-all`; neither target deletes images or touches unlabelled containers and networks.
 
 ## Bibliometrics
 
@@ -174,7 +195,11 @@ Sites created by `new_web` include a manual GitHub Pages workflow that delegates
 
 ## CI Scope
 
-Build, deploy, link-check, Docker image, publication metrics and CodeQL workflows are intentionally manual. Publication metrics run through the manual/reusable `.github/workflows/metrics-update.yml` workflow or local commands.
+`.github/workflows/ci.yml` runs automatically for pushes and pull requests. It compiles and unit-tests supported Python versions, checks patch whitespace, validates workflow and distribution structure, builds/tests the wheel and gem, then uses cached Docker builds for the MCP smoke test and reference docs. This normal CI intentionally runs `distribution-check`, not the strict release gate, so truthful `pending` companion releases do not block ordinary development.
+
+CodeQL separately analyzes JavaScript/TypeScript, Python and Ruby on pull requests, default-branch pushes and a weekly schedule. Docs deployment, link checks, publication metrics, package preparation and image publication remain manual.
+
+`distribution-release-check` is the publication boundary. Every image workflow runs it, validates the selected ref against the BOM version, runs relevant tests and builds without credentials before a dependent job can log in or push. `.github/workflows/package-prepare.yml` applies the same strict gate, builds checked gem/wheel candidates, writes SHA-256 checksums and uploads a workflow artifact named with the commit SHA. It does not upload to RubyGems or PyPI, create a GitHub release, tag the repository or publish an image. Those operations still require a separate explicit maintainer approval and action.
 
 ## Attribution
 

--- a/TODO.md
+++ b/TODO.md
@@ -59,7 +59,7 @@ The goal is not to maintain one personal site here. The goal is to make a self-o
 - Replaced the post-deploy link checker with a docs-only offline link check.
 - Added a manual/reusable publication metrics workflow at `.github/workflows/metrics-update.yml`.
 - Kept publication metrics PRs focused on versionable generated data: `_bibliography/**/*.bib` and `_data/metrics.yml`. Scimago caches and diagnostics remain unversioned.
-- Changed CodeQL to manual-only so automatic CI stays focused on web/docs.
+- Added automatic multi-language CodeQL and bounded PR/push CI without enabling automatic publication.
 - Fixed `scripts/biblio/fetch_scimago_csv.sh` so it validates Scimago data through its own script directory when called from child repositories.
 - Added clearer metrics failure reporting for missing Scimago data and OpenAlex/Crossref request errors.
 - Exposed local `METRICS_ARGS` and `SCIMAGO_INPUT` Makefile controls in both core and template repos.
@@ -87,7 +87,7 @@ Important current template behaviour:
 - Playwright render smoke tests verify `unaltreselfie`, `unaltreprojecte`, `unaltremanual` and `unaltredocs` profiles, desktop/mobile rendering, theme modes and screenshots.
 - The template deploy workflow calls `.github/workflows/site-deploy.yml` from this core.
 - The template manual `Update publication metrics` workflow calls `.github/workflows/metrics-update.yml` from this core.
-- The template local runtime defaults to `ghcr.io/dosquartsdedocs/unaltraweb:main`, while `LOCAL_CORE=../unaltraweb` remains the side-by-side development path.
+- The package scaffold local runtime defaults to the selected `ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0`; the external template fixture should align its consumer defaults while `LOCAL_CORE=../unaltraweb` remains the side-by-side development path.
 - The template README explains the four profiles, the GitHub-only content workflow and the local Docker workflow.
 
 ## Next Work
@@ -106,12 +106,16 @@ mcp_dependencies:
     required: true
     install: true
     build: true
-    init: true
-    remote: git@github.com:dosquartsdedocs/diavisuals.git
+    init: false
+    remote: https://github.com/dosquartsdedocs/diavisuals.git
     package: diavisuals
+    version: 0.3.1
+    release: v0.3.1
+    release_status: pending
     extras:
       - mcp
     required_tools:
+      - project_check
       - render_diagram
       - render_diagram_text
     suggested_path: ../diavisuals
@@ -128,11 +132,11 @@ mcp_dependencies:
 - Audit which JS/CSS/assets currently live in child repos versus the gem/core. Any copied core code in child sites should either move into `unaltraweb` or be marked as a deliberate local override.
 - Continue hardening Docker as the primary user-facing runtime: users should only need Docker plus Git for normal local `make serve`, `make build` and `make test` flows.
 - Decide whether future images should preinstall the `unaltraweb` gem or keep the current split where the image owns runtime dependencies and the child `Gemfile` owns theme/plugin code.
-- Add versioning guidance for `ghcr.io/dosquartsdedocs/unaltraweb:main`, `latest`, release tags and the template's default `DOCKER_IMAGE` value before recommending this outside the pre-release workflow; ensure the GHCR package is public after the first publish.
+- The versioned component BOM now selects release images and exact companion releases; mutable `main`/`latest` channels are documented as maintainer-only. Ensure every GHCR package is public after its first approved publish.
 - Keep a developer path for local core work: `LOCAL_CORE=../unaltraweb` and possibly a Git-based gem dependency remain useful for testing, but should not be the normal user setup.
 - Decide how `diavisuals` is distributed for users. Preferred direction: `unaltraweb diagrams` works without cloning `diavisuals`, either by packaging the style/render tooling into the core image or by invoking a versioned render image.
 - Add update commands with clear semantics: `make update-core` or `unaltraweb update` pulls the Docker image/tag and runs `doctor`; optional git-upstream updates should be limited to starter/template migrations, not core code.
-- Add `make doctor` or `unaltraweb doctor` to validate the contract in child repos: no copied `_layouts/_includes/_sass/assets/js` core files unless declared, required collections/data exist for the selected profile and generated assets are in sync.
+- Distribution doctor now validates release/factory/project pins and feature selection offline. Extend it later with explicit copied-core-asset detection and generated-asset synchronization checks rather than conflating those with distribution health.
 - Revisit documentation pages for creating a new site after the keep/sync commands exist. Current docs already cover: choose profile, edit content/config, and serve/build through Docker.
 
 - Next-session focus for `unaltremanual`: make the manual content usable as a student-facing downloadable/printable PDF, likely through LaTeX/Pandoc. Treat PDF output as a first-class target, and mark web-only enhancements so they degrade cleanly or are omitted in PDF builds.

--- a/assets/html/relativity.html
+++ b/assets/html/relativity.html
@@ -1,4 +1,9 @@
-<html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Relativity: The Special and General Theory</title>
+  </head>
   <body>
     <center>
       <h2>Relativity: the Special and General Theory</h2>

--- a/assets/plotly/demo.html
+++ b/assets/plotly/demo.html
@@ -1,5 +1,6 @@
-<html>
-<head><meta charset="utf-8" /></head>
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8" /><title>Plotly Demo</title></head>
 <body>
     <div>                        <script type="text/javascript">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>
         <script type="text/javascript">/**

--- a/docker-compose-slim.yml
+++ b/docker-compose-slim.yml
@@ -1,7 +1,7 @@
 # Kept as a lightweight compatibility compose file; it now uses the unaltraweb image.
 services:
   jekyll:
-    image: ghcr.io/dosquartsdedocs/unaltraweb:main
+    image: unaltraweb:dev
     #build: .
     ports:
       - 4000:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ name: unaltraweb
 services:
   jekyll:
     container_name: unaltraweb-jekyll
-    image: ghcr.io/dosquartsdedocs/unaltraweb:main
+    image: unaltraweb:dev
     build: .
     # uncomment these if you are having this issue with the build:
     # /usr/local/bundle/gems/jekyll-4.3.4/lib/jekyll/site.rb:509:in `initialize': Permission denied @ rb_sysopen - /srv/jekyll/.jekyll-cache/.gitignore (Errno::EACCES)

--- a/docs/_documentation/en/02-tools.md
+++ b/docs/_documentation/en/02-tools.md
@@ -30,7 +30,7 @@ nav_title: Local Tools
 The template uses the shared runtime image by default:
 
 ```bash
-ghcr.io/dosquartsdedocs/unaltraweb:main
+ghcr.io/dosquartsdedocs/unaltraweb:0.3.0
 ```
 
 That image provides Ruby, Bundler, Jekyll system dependencies, ImageMagick, Node for ExecJS and Python tooling needed by local commands. The GHCR package must be public before unauthenticated users can pull it.
@@ -45,6 +45,18 @@ make build
 make test
 make down
 ```
+
+Inspect the selected component contract and local project pins without network access:
+
+```bash
+unaltraweb-mcp doctor --project .
+unaltraweb-mcp doctor --project . --docker  # local image inspection only; never pulls
+unaltraweb-mcp --project . mcp site-doctor
+unaltraweb-mcp --project . mcp scaffold-sync
+unaltraweb-mcp --project . mcp html-audit
+```
+
+The generated `make test` builds and runs the offline HTML audit. `build_site` returns the same audit after a successful build. External URLs are inventoried but never fetched.
 
 ## Integration Template Commands
 
@@ -72,9 +84,9 @@ make down
 Run these from the `unaltraweb` repository when working on this reference site:
 
 ```bash
-make docs-serve DOCKER_IMAGE=unaltraweb:local
-make docs-build DOCKER_IMAGE=unaltraweb:local
-make docs-publish DOCKER_IMAGE=unaltraweb:local
+make docs-serve DOCKER_IMAGE=unaltraweb:dev
+make docs-build DOCKER_IMAGE=unaltraweb:dev
+make docs-publish DOCKER_IMAGE=unaltraweb:dev
 make docs-down
 ```
 
@@ -115,4 +127,4 @@ When the core docs and all template profiles are running together, use this conv
 - Keep deploy workflows as thin `workflow_dispatch` wrappers pinned to a reviewed full commit SHA of `dosquartsdedocs/unaltraweb/.github/workflows/site-deploy.yml`.
 - The optional integration template may retain its local `gh-pages` publishing target for testing that separate workflow.
 - After the first Docker publish, make `ghcr.io/dosquartsdedocs/unaltraweb` public.
-- Confirm `docker pull ghcr.io/dosquartsdedocs/unaltraweb:main` works without `docker login`.
+- Confirm `docker pull ghcr.io/dosquartsdedocs/unaltraweb:0.3.0` works without `docker login`.

--- a/docs/_documentation/en/03-usage.md
+++ b/docs/_documentation/en/03-usage.md
@@ -21,8 +21,8 @@ nav_title: Run And Preview
 
 1. Call `new_web` with one `unaltraweb.site_profile` and the site identity/language settings.
 2. Inspect the generated `_config.yml` and localized home page.
-3. Edit content and data files.
-4. Run `profile_check`, `site_check`, and `build_site`.
+3. Edit content and data files. MCP agents should read a source hash, review the default `site_source_write` dry-run, then apply the exact CAS update.
+4. Run `site_doctor`, `profile_check`, `site_check`, and `build_site`; review the returned HTML audit.
 5. Commit the reviewed site to `main`.
 6. Run the generated manual GitHub Pages workflow, or replace it with the workflow required by another host.
 
@@ -85,7 +85,11 @@ The generated repository contains one profile. Create a separate temporary site 
 - Gem updates change layouts, includes, Sass, plugins and scripts.
 - Docker image updates change local runtime dependencies and are published manually.
 - Reusable workflow updates change optional GitHub build and deploy behavior.
-- Package scaffold changes affect newly generated sites; existing repositories receive them only through an explicit migration.
+- Package scaffold changes affect newly generated sites. Existing generated repositories can review `scaffold_sync`, which manages only `.gitignore`, Makefile, Gemfile/lock, and the deploy workflow from `.unaltraweb/scaffold.json`; it never overwrites conflicts or changes config/content.
+
+## Safe MCP Editing
+
+`site_source_read`, `site_source_write`, and `site_source_delete` are deliberately restricted to `_config.yml`, Markdown/HTML content collections, YAML/JSON/CSV below `_data/`, and Markdown below `context/`. They do not expose generic filesystem access and cannot mutate workflows, runtime files, core overrides, bibliography, assets, or generated output. Writes default to dry-run and use SHA-256 optimistic concurrency; destructive deletes additionally require explicit confirmation and can never remove `_config.yml`.
 
 Dependabot can stay enabled for Bundler and GitHub Actions in child sites, but deploy workflows should remain manual so dependency pull requests do not consume deploy minutes automatically.
 

--- a/docs/_documentation/en/13-unaltremanual.md
+++ b/docs/_documentation/en/13-unaltremanual.md
@@ -94,13 +94,13 @@ source_roots:
 generated_assets_root: assets/img/generated
 engines:
   python:
-    image: ghcr.io/dosquartsdedocs/unaltraweb-compute-python:main
+    image: ghcr.io/dosquartsdedocs/unaltraweb-compute-python:0.3.0
     lockfiles:
       - requirements-compute.txt
     fingerprint_paths:
       - analysis/helpers
   r:
-    image: ghcr.io/dosquartsdedocs/unaltraweb-compute-r:main
+    image: ghcr.io/dosquartsdedocs/unaltraweb-compute-r:0.3.0
     lockfiles:
       - renv.lock
 ```

--- a/docs/_documentation/en/22-feature-reference.md
+++ b/docs/_documentation/en/22-feature-reference.md
@@ -42,7 +42,7 @@ The companion `unaltraweb-template` repository contains full-profile demos becau
 - Add a data-file reference for `_data/` files used by team, repositories, metrics, readings and profile-specific pages.
 - Add profile-specific checklists for creating real sites from the template.
 - Add screenshots or visual examples for the four profiles without duplicating the full template demo.
-- Document future `keep`, `sync`, `doctor` or equivalent commands when they exist.
+- Keep future `keep`/`sync` behavior separate from the existing offline distribution `doctor`; document migrations only when those commands exist.
 - Expand manual/PDF guidance once printable manual output becomes a first-class target.
 
 ## Where To Look Today

--- a/docs/_documentation/en/31-template.md
+++ b/docs/_documentation/en/31-template.md
@@ -21,7 +21,7 @@ nav_title: Core And Template
 - It consumes `unaltraweb` as an external dependency.
 - It contains realistic demo content for `unaltreselfie`, `unaltreprojecte`, `unaltremanual` and `unaltredocs` profiles.
 - It exercises richer local Docker and browser-test orchestration than the clean package scaffolds.
-- It uses the shared `ghcr.io/dosquartsdedocs/unaltraweb:main` runtime image by default.
+- It uses the selected `ghcr.io/dosquartsdedocs/unaltraweb:0.3.0` runtime image by default; mutable `main` is reserved for maintainer testing.
 - It runs Playwright smoke tests and screenshots across profiles, themes and responsive layouts.
 - It keeps rich demo content out of clean profile scaffolds.
 

--- a/docs/_documentation/en/32-development.md
+++ b/docs/_documentation/en/32-development.md
@@ -31,14 +31,22 @@ The core repository can publish the `unaltraweb` reference site from `docs/` wit
 The reference site is a real child site of the local `unaltraweb` gem. It uses `theme: unaltraweb`, the shared layouts/includes/Sass, and `unaltraweb.site_profile: unaltredocs`.
 
 ```bash
-make docs-serve DOCKER_IMAGE=unaltraweb:local
-make docs-build DOCKER_IMAGE=unaltraweb:local
-make docs-publish DOCKER_IMAGE=unaltraweb:local
+make docs-serve DOCKER_IMAGE=unaltraweb:dev
+make docs-build DOCKER_IMAGE=unaltraweb:dev
+make docs-publish DOCKER_IMAGE=unaltraweb:dev
 ```
 
-After the published Docker image is available, omit `DOCKER_IMAGE=unaltraweb:local`.
+After the selected versioned Docker image is available, omit `DOCKER_IMAGE=unaltraweb:dev`.
 
-Docs deploys, link checks, Docker image publishing and CodeQL are intentionally manual to avoid consuming Actions minutes on every push.
+Docs deploys, link checks, publication metrics and all publication workflows remain manual. CodeQL and the repository CI workflow run automatically; neither deploys or publishes anything.
+
+## Automatic CI
+
+`.github/workflows/ci.yml` runs on pull requests and pushes. Its bounded jobs cover Python 3.10/3.13 compile and unit checks, `git diff --check`, workflow policy, structural `distribution-check`, clean wheel and gem checks, and cached Docker builds followed by MCP smoke and docs builds. CodeQL analyzes JavaScript/TypeScript, Python and Ruby for pull requests, default-branch pushes and its weekly schedule.
+
+Automatic CI deliberately uses the structural gate. It verifies that pending companion releases are represented truthfully but does not require them to be published, so normal feature work can remain green before a coordinated release.
+
+`make distribution-release-check` is stricter: it exits nonzero while any selected component is `pending` or `unavailable`. Manual image workflows and the package-candidate workflow run that strict gate, exact ref/version validation and relevant tests before any registry login or image push is reachable. Starting a manual workflow is still an explicit approval; package preparation only uploads commit-SHA-named workflow artifacts and does not publish to RubyGems/PyPI or create a GitHub release.
 
 ## Core Build
 
@@ -57,7 +65,7 @@ docker compose -f docker-compose.yml down --remove-orphans
 
 This can be resource-heavy because the inherited demo build minifies JavaScript and can generate many responsive WebP images.
 
-The same Dockerfile is published to GHCR as `ghcr.io/dosquartsdedocs/unaltraweb:main` by the manual `.github/workflows/docker-image.yml` workflow. Template repositories use that image as their default local runtime, while the `unaltraweb` gem remains the source of theme files and plugins.
+The same Dockerfile is published manually. Consumers select `ghcr.io/dosquartsdedocs/unaltraweb:0.3.0`; the mutable `ghcr.io/dosquartsdedocs/unaltraweb:main` channel and local `unaltraweb:dev` name are explicit maintainer paths. The `unaltraweb` gem remains the source of theme files and plugins.
 
 The root core build excludes `docs/`. The reference site is published from the `docs/` folder through a dedicated workflow so its root-relative permalinks do not collide with the inherited core demo build.
 

--- a/docs/_documentation/en/33-reusable-workflows.md
+++ b/docs/_documentation/en/33-reusable-workflows.md
@@ -70,8 +70,9 @@ jobs:
       dockerfile: Dockerfile.compute-python
       context: .
       base_image: ghcr.io/dosquartsdedocs/unaltraweb-compute-python@sha256:<digest>
+      test_command: make test-compute-image
 ```
 
-Pin the reusable workflow to a reviewed commit because it receives the caller's package-write token. The workflow checks out the consumer repository, passes `BASE_IMAGE`, and publishes `main` and `sha-*` under the consumer repository owner. It also publishes release-tag metadata when invoked from a tag ref. Keep engine-specific dependencies and lockfiles in that project; for example, a TIGIT site should publish `tigit-compute-r`, not a TIGIT variant of the core package.
+Pin the reusable workflow to a reviewed commit because it receives the caller's package-write token. Before a login is possible, the workflow checks that exact core revision with `distribution-release-check`, requires a digest-pinned `base_image`, validates confined build paths and the default-branch or `vX.Y.Z` ref, runs the optional project test command, and completes a no-push image build. Only the dependent publication job can publish `main` and `sha-*` under the consumer repository owner or semver/release-tag metadata from a release tag. Published images include SBOM and provenance attestations. Keep engine-specific dependencies and lockfiles in that project; for example, a TIGIT site should publish `tigit-compute-r`, not a TIGIT variant of the core package.
 
 After publication, make the package public or authenticate Docker, select its full GHCR digest in `.unaltraweb/computations.yml`, run `manual-compute-render`, and commit the updated generated artifacts and computation lock. Publishing an extension does not select or rerender it automatically.

--- a/docs/_documentation/en/40-distribution.md
+++ b/docs/_documentation/en/40-distribution.md
@@ -23,6 +23,28 @@ nav_title: Distribution Model
 
 The template is the better place to validate gem consumption, centralized styles and shared logic because it runs as a child site. It is not required to create a site: package scaffolds are the supported clean starting point.
 
+## Component Contract
+
+`src/unaltraweb_mcp/component-contract.json` is the canonical versioned bill of materials. `component-contract.schema.json` defines schema version 1. Runtime loading and `scripts/validate_distribution.py` validate the complete document against that schema, then enforce semantic parity between versions, release tags, repositories, references, wheel contents, and CLI availability.
+
+The BOM is an interoperability contract, not a bundle. The wheel contains only its Python control/inspection modules, schema/BOM, and clean package-owned scaffolds. In particular it does not contain Ruby theme assets, Docker image layers, factory Make/scripts/docs, TeX, Chromium, computation environments, `diavisuals`, or `vegavisuals`.
+
+For the selected release, the core-owned container references use `0.3.0`; `diavisuals v0.3.1` and `vegavisuals v0.3.1` remain explicitly pending compatibility selections. Current checkouts can be used through `suggested_path`, but the BOM, factory manifest, validator, and doctor do not claim that either tag has been published. `distribution-check` validates structural contract integrity and remains green for normal pre-release CI. `distribution-release-check` additionally requires all selected external releases to be published and exits with release-readiness status `2` while either release remains pending.
+
+## Wheel And Doctor
+
+A clean `unaltraweb-mcp` wheel works without a factory checkout for `version`, `new-web`, top-level `doctor`, constrained source management, scaffold synchronization, `site-doctor`, HTML audit, and pure inspection where feasible. Examples include `mcp list-tools`, `starter-templates`, `detect-site`, `site-context`, `profile-check`, content/language/bibliography inventories, and `build-health`.
+
+```bash
+unaltraweb-mcp doctor
+unaltraweb-mcp doctor --project /path/to/site
+unaltraweb-mcp doctor --project /path/to/site --docker
+```
+
+Doctor performs no network requests. It reports limited wheel mode as an informational healthy state, reads `_config.yml`, Gemfile/lock, Make pins, computation settings, capture recipes, PDF enablement, and companion manifests when a project is supplied, and checks only components relevant to those features. `release_ready` is separate from operational `ok`, so a pending or unavailable companion release is visible without making package-only inspection unusable. `--docker` optionally inspects local Docker and selected image presence; it never pulls or builds. Every finding has stable `code`, `severity`, `expected`, `actual`, and `remediation` fields.
+
+Factory-backed MCP serving, site preflight/build, computations, captures, PDF operations, bibliometrics, and prompt loading still require the checkout or the selected MCP image. A wheel invocation fails those commands explicitly and tells the caller to set `UNALTRAWEB_FACTORY_DIR`; it does not pretend the factory assets were bundled.
+
 ## User Paths
 
 ### GitHub-only editing
@@ -62,7 +84,7 @@ make test LOCAL_CORE=../unaltraweb SITE_PROFILE=unaltreprojecte
 
 The core repository deploy workflow is manual. It builds only `docs/` and publishes it with GitHub Pages Actions. The root core Jekyll build excludes `docs/`, so the reference site can use its own root-relative permalinks without colliding with the internal core demo build.
 
-Deploys, link checks, Docker image publishing, publication metrics and CodeQL run manually from GitHub or locally.
+Reference deployment, link checks, Docker image publishing and publication metrics run manually from GitHub or locally. Repository CI runs for pushes and pull requests, and CodeQL runs for pull requests, default-branch pushes and a weekly schedule. Neither automatic workflow deploys or publishes.
 
 ## Updates
 
@@ -73,11 +95,13 @@ For that reason:
 - normal improvements should ship through the `unaltraweb` gem or reusable workflows;
 - site repositories can enable Dependabot for Bundler and GitHub Actions, but deploy workflows should remain manual;
 - breaking changes should be released with migration notes;
-- scaffold changes should be rare and, when needed, delivered as explicit pull requests or a future `unaltraweb sync` command.
+- scaffold changes should be rare; generated sites can explicitly dry-run `scaffold_sync`, which updates only unchanged baseline runtime files, creates newly managed missing files, reports conflicts, never deletes paths, stages every output, rechecks adopted and unchanged files around the manifest write, rolls the whole transaction back on failure, and commits its manifest last.
 
 ## Docker Runtime
 
-The shared runtime image is published from the core repository as `ghcr.io/dosquartsdedocs/unaltraweb:main` and `ghcr.io/dosquartsdedocs/unaltraweb:latest` by the manual Docker image workflow. Release tags are available when the workflow is run from a `v*` tag. The workflow avoids default SHA image tags and uses GitHub Actions caches for repeat builds. The image carries Ruby, Bundler, Jekyll system dependencies, ImageMagick, Node for ExecJS and Python tooling needed by local builds. The GHCR package must be public before unauthenticated template users can pull it.
+The selected consumer runtime is `ghcr.io/dosquartsdedocs/unaltraweb:0.3.0`. Release tags are published only by manually running the Docker workflow from the exact BOM tag. The workflow may also publish `main`/`latest` from the default branch, but those mutable channels are maintainer development channels and are not consumer defaults. Local maintainer images use explicit names such as `unaltraweb:dev`.
+
+The same rule applies to workers: consumer defaults select the `0.3.0` computation, capture, and PDF images. The manual workflows retain explicitly declared `main` and `sha-*` channels for maintainers while producing the semver tag required by the BOM. The image set remains separate so ordinary site or wheel installs do not acquire Chromium, TeX, Python/R computation stacks, or Docker layers they do not use.
 
 The image is not the source of layouts or styles. Child sites still get those from the `unaltraweb` gem declared in their `Gemfile`. This keeps updates centralized in two places:
 
@@ -86,17 +110,28 @@ The image is not the source of layouts or styles. Child sites still get those fr
 
 Before recommending the local Docker workflow to unauthenticated users, complete this first-publish checklist:
 
-- Create the release tag, then run the manual `.github/workflows/docker-image.yml` workflow from `v0.3.0` to publish both versioned images.
+- Create the release tag, then run the manual `.github/workflows/docker-image.yml` workflow from `v0.3.0` to publish the runtime, MCP and manual PDF images.
 - Open the `ghcr.io/dosquartsdedocs/unaltraweb` package settings in GitHub.
 - Make the package public.
-- Confirm that `docker pull ghcr.io/dosquartsdedocs/unaltraweb:main` works without `docker login`.
+- Confirm that `docker pull ghcr.io/dosquartsdedocs/unaltraweb:0.3.0` works without `docker login`.
 - Make the `ghcr.io/dosquartsdedocs/unaltraweb-mcp` package public after its first publication.
 - Confirm that `docker pull ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0` works without `docker login`.
+
+This checklist describes future publication verification; changing the contract does not publish, tag, or release any artifact.
+
+## CI And Release Gates
+
+Automatic `.github/workflows/ci.yml` uses `distribution-check`. It validates schema/version/reference parity and release-status declarations, but permits a selected companion to remain explicitly `pending` or `unavailable`. It also runs Python compile/unit/diff checks, wheel/gem checks, workflow policy, MCP smoke and the docs build. CodeQL is an independent automatic security check for JavaScript/TypeScript, Python and Ruby.
+
+`distribution-release-check` is the strict publication gate. Every core or reusable image publication workflow runs it in an unprivileged preflight, validates the default-branch or exact semver release ref, runs relevant tests and completes a no-push build before the dependent package-write job can log in. Published images enable BuildKit SBOM and maximum provenance attestations. The MCP publication consumes the immutable digest emitted by the runtime publication build, not `main`, `latest` or a version tag.
+
+The manual `.github/workflows/package-prepare.yml` builds and checks the gem and wheel, writes `SHA256SUMS`, and uploads an immutable workflow artifact whose name includes the source commit SHA. It does not call RubyGems, PyPI or GitHub Releases. Passing CI, passing the strict gate and preparing candidates are evidence for a release, not authorization to publish: tagging, starting a credentialed image workflow, uploading language packages and creating a GitHub release remain separate explicit maintainer approvals.
 
 ## Verification
 
 Core changes should be validated in two layers:
 
+- Run `make workflow-check`, `make distribution-check`, `make wheel-check`, and `make gem-check` for workflow publication policy, version/schema parity, selected release metadata, CLI/wheel boundaries, clean wheel installation, and built-gem content. Run `make distribution-release-check` only at publication time to require release readiness. `gem-check` uses local RubyGems or an already-local selected runtime image and never pulls implicitly.
 - Build the core repository to catch internal Jekyll errors.
 - Build or test `../unaltraweb-template` with `LOCAL_CORE=../unaltraweb` to catch consumer-path regressions.
 

--- a/docs/_documentation/en/42-docker-image.md
+++ b/docs/_documentation/en/42-docker-image.md
@@ -16,20 +16,20 @@ nav_title: Docker Image
 The shared image is published from the core repository:
 
 ```text
-ghcr.io/dosquartsdedocs/unaltraweb:main
+ghcr.io/dosquartsdedocs/unaltraweb:0.3.0
 ```
 
 It provides the runtime environment: Ruby, Bundler, Jekyll system dependencies, ImageMagick, Node for ExecJS and Python tooling.
 
 The image is not the source of layouts and styles. Those come from the `unaltraweb` gem in the child site's `Gemfile`.
 
-The GHCR package is kept because it makes the local Docker workflow cheap and repeatable. Publishing the image is manual: run `.github/workflows/docker-image.yml` only when runtime dependencies change. The workflow publishes `main`/`latest` from the default branch and release tags from tag refs; it does not publish per-commit SHA tags by default.
+The GHCR package is kept because it makes the local Docker workflow cheap and repeatable. Publishing the image is manual: run `.github/workflows/docker-image.yml` only when runtime dependencies change and after reviewing its strict release preflight. The versioned tag is the consumer default. `main`/`latest` are mutable maintainer channels published from the default branch; they are not release pins. The workflow builds and tests all images before registry login, emits SBOM/provenance attestations, and builds the MCP image from the exact newly published runtime digest.
 
 During local core development, use the locally built image:
 
 ```bash
-docker build -t unaltraweb:local .
-make docs-serve DOCKER_IMAGE=unaltraweb:local
+docker build -t unaltraweb:dev .
+make docs-serve DOCKER_IMAGE=unaltraweb:dev
 ```
 
 After the first GHCR publish, make the package public and confirm unauthenticated pulls work.
@@ -39,8 +39,8 @@ After the first GHCR publish, make the package public and confirm unauthenticate
 Executable manual chapters use separate images from the Jekyll runtime and PDF builder:
 
 ```text
-ghcr.io/dosquartsdedocs/unaltraweb-compute-python:main
-ghcr.io/dosquartsdedocs/unaltraweb-compute-r:main
+ghcr.io/dosquartsdedocs/unaltraweb-compute-python:0.3.0
+ghcr.io/dosquartsdedocs/unaltraweb-compute-r:0.3.0
 ```
 
 The Python image provides Quarto, Jupyter, NumPy, pandas, Matplotlib, GeoPandas, and geospatial libraries. The R image builds on `rocker/geospatial`, preserves RStudio Server, and adds Quarto, `knitr`, `rmarkdown`, `renv`, and the computation driver.
@@ -148,7 +148,7 @@ The target prepares the image, mounts the project at `/home/rstudio/project`, ma
 
 ### Publish To GHCR
 
-Core maintainers publish both base images with the manual `Compute images` workflow in `.github/workflows/compute-images.yml`. Its matrix produces separate Python and R packages with default-branch `main`, commit `sha-*`, and release-tag metadata. Packages intended for child sites must allow unauthenticated pulls.
+Core maintainers publish both base images with the manual `Compute images` workflow in `.github/workflows/compute-images.yml`. Its strict, no-credentials preflight and no-push build matrix must complete before its package-write matrix can start. Published Python and R packages carry SBOM/provenance and default-branch `main`, commit `sha-*`, and semver/release-tag metadata. Consumer defaults use the semver tag; `main` and `sha-*` are explicitly maintainer channels. Packages intended for child sites must allow unauthenticated pulls.
 
 Projects can call `.github/workflows/project-compute-image.yml` to publish their own extension package. Use a separate package name such as `example-compute-r`; do not encode project dependencies as variants of `unaltraweb-compute-r`.
 
@@ -159,9 +159,11 @@ The current publication workflows build `linux/amd64` images. ARM authors need D
 Selector-based screenshot authoring uses a separate Playwright image rather than adding Chromium to the Jekyll runtime:
 
 ```text
-ghcr.io/dosquartsdedocs/unaltraweb-web-capture
+ghcr.io/dosquartsdedocs/unaltraweb-web-capture:0.3.0
 ```
 
-The image contains pinned Playwright/Chromium, the capture worker, the Python status controller, and the core visual sources used in fingerprints. `make web-capture-image` builds the local image; the manual `Web capture image` workflow publishes default-branch, commit, and release tags to GHCR.
+The image contains pinned Playwright/Chromium, the capture worker, the Python status controller, and the core visual sources used in fingerprints. `make web-capture-image` builds the explicitly named `unaltraweb-web-capture:dev` maintainer image; set `WEB_CAPTURE_IMAGE` to that name when testing it. The manual `Web capture image` workflow publishes default-branch, commit, and semver/release tags to GHCR.
+
+Manual PDF commands similarly consume `ghcr.io/dosquartsdedocs/unaltraweb-manual-pdf:0.3.0` by default. `manual-pdf-image` reuses or pulls that selected image instead of rebuilding it locally. Maintainers use `make manual-pdf-image-dev` and then pass `MANUAL_PDF_IMAGE=unaltraweb-manual-pdf:dev` for local PDF runtime changes.
 
 Rendering creates an ephemeral Docker `--internal` network shared only by Jekyll and Chromium, keeps browser requests on the preview origin, blocks service workers, popups, and WebSockets, drops Linux capabilities, uses a read-only container root and bounded resources, and writes only the declared PNG/SVG outputs under the mounted project. Ordinary checks run without browser execution or network access.

--- a/docs/agents/action-prompts/10-content-update.txt
+++ b/docs/agents/action-prompts/10-content-update.txt
@@ -3,6 +3,7 @@ Update one `unaltraweb` content item.
 1. Identify the profile and content type before editing: page, post, news item, project, output, chapter, documentation page, book, thesis, or `_data` record.
 2. Preserve front matter keys used for routing: `title`, `lang`, `ref`, `permalink`, `profiles`, `feature`, `section`, and `weight` when relevant.
 3. Draft and approve substantial content in the configured default language first. For multilingual content, keep `ref` stable across languages and do not silently update translations while the default-language source is still changing.
-4. Prefer small versionable edits over generated churn. Do not edit `_site`, `tmp`, or local caches.
-5. Use `translation_plan` before publication to identify approved default-language content that still needs localization.
-6. Run `profile_check` and a build check when the edit changes navigation, layout, links, or collection structure.
+4. Use `site_source_read` and its SHA-256 before `site_source_write`; review the default dry-run diff, then apply the exact CAS update. New files require `create_only=true`.
+5. Prefer small versionable edits over generated churn. Do not use these tools for bibliography, assets, workflows, Makefiles, layouts, plugins, Sass, or generated paths.
+6. Use `translation_plan` before publication to identify approved default-language content that still needs localization.
+7. Run `profile_check` and a build check when the edit changes navigation, links, or collection structure.

--- a/docs/agents/action-prompts/70-build-and-review.txt
+++ b/docs/agents/action-prompts/70-build-and-review.txt
@@ -1,11 +1,12 @@
 Build and review an `unaltraweb` site change.
 
-1. Run `site_check`; resolve profile, freshness, computation, capture, bibliography, and editorial failures before building.
-2. When `site_check` reports delegated Vega validation, run the companion `visualization_check` before building.
+1. Run `site_doctor` and `site_check`; resolve distribution, scaffold, profile, freshness, computation, capture, bibliography, and editorial failures before building.
+2. When `site_check` reports a required companion gate, run the selected provider check and retain its verifiable `.unaltraweb/receipts/<provider>.json`; never substitute a caller-provided success flag.
 3. Render stale computation or capture artefacts explicitly, preserving edited SVG overrides, then rerun their checks.
 4. Run `build_site`, passing `site_profile` when reviewing a specific profile override.
-5. If a preview server is already running, call `http_check` with the expected local base URL and key paths.
-6. For visual or browser-level checks, use the consumer site's existing Playwright/render-smoke Make targets rather than inventing a new server workflow.
-7. For visible content changes, start or reuse the local `make serve` preview and ask the human author to review the rendered site in their browser.
-8. Do not commit or publish content changes until the human author explicitly approves that served preview.
-9. Summarize build failures with the relevant target, return code, and the actionable stderr/stdout tail.
+5. Review the `html_audit` returned by a successful `build_site`; resolve broken local targets/fragments and document accessibility findings before previewing.
+6. If the project-owned preview is already running, call `http_check` with key local paths. Never supply or probe an arbitrary origin.
+7. For visual or browser-level checks, use the consumer site's existing Playwright/render-smoke Make targets rather than inventing a new server workflow.
+8. For visible content changes, start or reuse the local `make serve` preview and ask the human author to review the rendered site in their browser.
+9. Do not commit or publish content changes until the human author explicitly approves that served preview.
+10. Summarize build failures with the relevant target, return code, timeout state, and the bounded actionable stderr/stdout.

--- a/docs/agents/manual-authoring-components.md
+++ b/docs/agents/manual-authoring-components.md
@@ -146,7 +146,7 @@ Store Vega-Lite specifications as `*.vl.json` and raw Vega specifications as `*.
 ![Quarterly totals](assets/charts/quarterly.vl.json "Quarterly totals"){: data-figure-width-web="42rem" data-figure-width-pdf="78%"}
 ```
 
-The web and PDF builders resolve the source through the manifest and use the same declared output. A source used as a web image must produce SVG or PNG; prefer SVG for web/PDF parity. Render with `make visualization-render`, commit the specification, output, manifest, and `.vegavisuals.lock.json`, and do not publish while `make visualization-check` or the companion `visualization_check` MCP tool reports stale, missing, unmanaged, or modified output. Reference a generated output directly when one source intentionally has multiple render variants.
+The web and PDF builders resolve the source through the manifest and use the same declared output. A source used as a web image must produce SVG or PNG; prefer SVG for web/PDF parity. Declare non-source files through manifest `inputs`; project-relative static `data.url` references in strict JSON specifications are discovered recursively as well. Receipt verification requires that exact union and rejects remote, dynamic, absolute, or escaping data URLs. Render with `make visualization-render`, commit the specification, inputs, output, manifest, and `.vegavisuals.lock.json`, then run the companion `visualization_check` so the provider publishes its verifiable receipt. Do not publish while the check or receipt verification reports stale, missing, unmanaged, modified, or hash-mismatched output. Reference a generated output directly when one source intentionally has multiple render variants.
 
 ## Web captures
 

--- a/docs/agents/mcp-contract.md
+++ b/docs/agents/mcp-contract.md
@@ -1,6 +1,6 @@
 # MCP Contract
 
-`unaltraweb` exposes one global, on-demand stdio MCP server for website workspaces. Every client session starts a Dockerized MCP process and mounts its current consumer project at `/workspace` and at its canonical host path. The image includes both FastMCP and the Jekyll runtime, so the host does not need Python, the optional `mcp` package, Ruby, or Bundler.
+`unaltraweb` exposes one global, on-demand stdio MCP server for website workspaces. Every client session starts an independently named Dockerized MCP process and mounts its current consumer project at `/workspace` and at its canonical host path. Stable factory, role, and project labels preserve project-scoped lifecycle control without forcing concurrent sessions to share a deterministic container name. The image includes both FastMCP and the Jekyll runtime, so the host does not need Python, the optional `mcp` package, Ruby, or Bundler.
 
 The client registration should launch:
 
@@ -8,23 +8,33 @@ The client registration should launch:
 make --silent --no-print-directory -C ${factoryRoot} mcp-stdio 'PROJECT=${workspaceFolder}'
 ```
 
-The opened workspace is the consumer website repository. Factory logic is embedded in `ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0`. The launcher pulls that public image when it is not already present. Global clients that do not substitute `${workspaceFolder}` must preserve their startup directory before `make -C` runs:
+The opened workspace is the consumer website repository. Factory logic is embedded in `ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0`. The launcher pulls that public image when it is not already present. This is the canonical ContExt transport from `mcp-factory.yml`. For global Codex and OpenCode registration, ContExt converts `${workspaceFolder}` into a launch-time shell wrapper that preserves the startup directory before `make -C` runs:
 
 ```bash
-/bin/sh -c 'exec env PROJECT="$PWD" make --silent --no-print-directory -C /path/to/unaltraweb mcp-stdio'
+/bin/sh -c 'workspace=$PWD; exec make --silent --no-print-directory -C /path/to/unaltraweb mcp-stdio PROJECT="$workspace"'
 ```
 
-Replace `/path/to/unaltraweb` with the checkout's absolute path. `PROJECT=.` is invalid in that global form because it resolves to the factory checkout after `make -C`. Restart clients such as OpenCode after changing their MCP registration.
+Replace `/path/to/unaltraweb` with the checkout's absolute path. `PROJECT=.` is invalid after `make -C` because it resolves to the factory checkout. The declared launcher remains `make`, which ContExt permits for a container runtime without a `runtime.allowed_host_launchers` exception; the shell is introduced only in generated client configuration. Restart clients such as OpenCode after changing their MCP registration.
+
+ContExt dependency preparation builds the runtime and required companions but does not initialize consumer content. The manifest does not advertise an `init` command, and both companion dependencies set `init: false`. Use `new_web` explicitly when a new consumer site should be created.
+
+The Python wheel remains modular. Without a factory checkout it supports `version`, `new-web`, top-level `doctor`, and the exact package-only MCP inventory declared in `component-contract.json`. The complementary exact inventory fails clearly with `UNALTRAWEB_FACTORY_DIR` remediation. `diavisuals v0.3.1` and `vegavisuals v0.3.1` are marked pending until those external tags exist, while explicitly selected current checkouts remain usable. Neither companion is bundled in the wheel or MCP server namespace.
 
 Static Vega-Lite and Vega rendering remains owned by the required companion `vegavisuals` MCP dependency. Use its `visualization_status`, `visualization_check`, `render_visualizations`, and `vegavisuals://project/*` resources directly; `unaltraweb` exposes the authoring syntax but does not proxy those tools into the `web://` server.
 
-When `.vegavisuals.yml` exists, `site_check` reports the delegated `visualization_check` requirement without trying to execute the companion CLI inside the unaltraweb container. Run that check through the separately registered `vegavisuals` MCP before `build_site`.
+When companion-owned sources exist, unaltraweb does not accept a caller-provided success boolean and does not proxy the provider implementation. The provider must write `.unaltraweb/receipts/vegavisuals.json` or `.unaltraweb/receipts/diavisuals.json`; `site_check`, `site_doctor`, and `build_site` independently verify the provider identity/version/release, current request hash, exact expected input and artifact inventories, and every input and artifact SHA-256. Missing, stale, malformed, non-finite, oversized, symlinked, inventory-mismatched, or hash-mismatched receipts block the required gate.
+
+A version-1 receipt contains only the provider result contract: `schema_version`, `provider`, `provider_version`, `release`, `request_sha256`, `ok: true`, `inputs`, and `artifacts`. Each non-source input and each artifact has exactly `path` and lowercase `sha256`; unaltraweb independently derives the complete expected input set and rehashes every entry, so omission or modification of a dataset invalidates the receipt. For vegavisuals, expected inputs are the union of top-level manifest `inputs`, each `visualizations[].inputs`, and every project-relative static `data.url` recursively found in the strict JSON specifications. Recursion is bounded. Remote URLs, dynamic URL values or interpolation, query/fragment URLs, absolute paths, traversal, missing files, and symlinked paths are unverifiable errors. For diavisuals, expected inputs are exactly empty until a versioned local-include contract is defined.
+
+The request digest is SHA-256 over `unaltraweb-companion-receipt-v1\0OWNER\0`, followed for each sorted provider source by its UTF-8 project-relative path and bytes, each prefixed by an unsigned eight-byte big-endian length. Vega sources are the manifest and all project Vega/Vega-Lite specifications; diagram sources are all supported Mermaid and PlantUML files. Receipt publication remains provider-owned, but a provider cannot expand or reduce the input inventory accepted by unaltraweb.
 
 ## Resources
 
 | Resource | Description |
 | --- | --- |
+| `web://distribution` | Package-owned component BOM plus offline, feature-aware doctor findings for the current factory and project. |
 | `web://site-context` | Site profile, feature flags, content inventory, bibliography, bibliometrics, and build state. |
+| `web://site-doctor` | Read-only offline distribution, project-contract, freshness, scaffold-drift, and core-override findings. |
 | `web://starter-templates` | Starter website templates available to initialize a new workspace. |
 | `web://profile-contract` | Checks for `unaltreselfie`, `unaltreprojecte`, `unaltremanual`, and `unaltredocs`. |
 | `web://profile-prune-plan` | Dry-run list of profile-specific content that can be removed from the active profile. |
@@ -46,12 +56,18 @@ When `.vegavisuals.yml` exists, `site_check` reports the delegated `visualizatio
 
 | Tool | Notes |
 | --- | --- |
+| `distribution_doctor` | Return offline component/factory/project findings with stable codes and optional local Docker image inspection that never pulls. |
 | `new_web` | Create a profile-specific site from package-owned assets after a complete collision, path, and symlink preflight. |
 | `starter_templates` | List package-owned profile scaffolds under the legacy inventory name. |
 | `initialize_site` | Compatibility alias for `new_web`; external templates and overwrite mode are rejected. |
 | `detect_site` | Detect an unaltraweb consumer from `_config.yml` and `Gemfile`, and report whether its Makefile exposes the native build/serve contract. |
 | `site_context` | Read the main local state for an agent session. |
-| `site_check` | Run profile, freshness, bibliography, bibliometrics, and build-state checks without network. |
+| `site_doctor` | Combine distribution doctor with strict project config, identity/language, generated Make contract, scaffold drift, required generated-output/receipt status, existing HTML audit, companion actions, and core override inventory. Unknown required status is blocking. Read-only and offline. |
+| `site_check` | Run profile, freshness, companion visualization/diagram receipt, bibliography, bibliometrics, and build-state checks without network. |
+| `site_source_read` | Read one allowed UTF-8 site source and return its exact SHA-256. |
+| `site_source_write` | Dry-run or atomically create/update one allowed source. Creates require `create_only`; updates require the exact SHA-256 returned by a read. |
+| `site_source_delete` | Dry-run or delete one allowed source with exact SHA-256 and explicit confirmation. It never deletes `_config.yml` or directories. |
+| `scaffold_sync` | Dry-run or transactionally synchronize the five package-managed runtime files against `.unaltraweb/scaffold.json`; edited files are conflicts, every output is staged, adopted and unchanged files are rechecked before and after the last manifest write, and rollback covers partial apply. |
 | `profile_check` | Check current profile and expected content/config paths. |
 | `manual_source_quality_check` | For `unaltremanual`, check captioned tables and figures, resolve local visual sources, compare embedded SVG text with body text on web/PDF, and suggest support-specific dimensions. |
 | `manual_editorial_quality_check` | Reject non-publishable metatext, user/agent instructions, workflow markers, drafting notes, and placeholders in manual bodies; return the editorial review checklist and local writing-profile path. |
@@ -67,7 +83,7 @@ When `.vegavisuals.yml` exists, `site_check` reports the delegated `visualizatio
 | `manual_pdf_build` | Build one or all configured language PDFs and first-page cover previews under `tmp/`. |
 | `manual_pdf_publish` | Copy built PDFs and covers to configured public assets. Defaults to dry-run; real publication requires explicit confirmation. |
 | `profile_prune_plan` | List content files whose explicit `profiles:` front matter excludes the selected profile. |
-| `profile_prune` | Remove those profile-specific files only after reviewing the plan and passing `confirm_prune=true`. Defaults to dry-run. |
+| `profile_prune` | Remove those profile-specific files only after reviewing the plan and passing `confirm_prune=true`. Empty-directory cleanup is descriptor-relative and never follows collection-root or ancestor symlinks. Defaults to dry-run. |
 | `content_inventory` | Inventory pages, posts, chapters, documentation, data, and assets. |
 | `language_policy` | Inspect `lang`, `default_lang`, `languages`, and the default-language-first editorial workflow. |
 | `content_approval_inventory` | Summarize `content_status` values, approved default-language sources, and pending default-language content. |
@@ -78,28 +94,39 @@ When `.vegavisuals.yml` exists, `site_check` reports the delegated `visualizatio
 | `bibliometrics_check` | Run the factory's offline metrics check against the consumer project. |
 | `bibliometrics_fetch_scimago` | Fetch or validate Scimago input through the factory against the consumer project. |
 | `bibliometrics_update` | Run the factory's metrics update against the consumer project. |
-| `build_site` | Run `make build-native LOCAL_CORE=/opt/unaltraweb` inside the current MCP container, optionally with `SITE_PROFILE`; this never launches a nested Jekyll container. |
+| `build_site` | Verify required companion provider receipts, run `make build-native LOCAL_CORE=/opt/unaltraweb` inside the current MCP container, optionally with `SITE_PROFILE`, then require a clean `html_audit`; this never launches a nested Jekyll container. |
 | `build_health` | Inspect existing `_site` artefacts without running Jekyll. |
+| `html_audit` | Audit `_site` internal links/assets/fragments, duplicate IDs, unresolved Liquid, image alt attributes, title, and HTML language; inventory external links without fetching them. |
 | `preview_start` | Start the single labelled preview container for the current project and wait for HTTP readiness. |
 | `preview_status` | Inspect that project's preview, including browser and container-internal URLs and optional recent logs. |
 | `preview_stop` | Remove only that project's labelled preview container. |
-| `http_check` | Probe an already-running Jekyll preview over HTTP. |
+| `http_check` | Probe bounded safe paths on the current project's owned labelled preview. The origin is derived internally; redirects and arbitrary origins are rejected. |
 
 Advanced computation, capture, PDF, and bibliometrics tools delegate to factory-owned Make targets against the consumer project. Fresh package scaffolds therefore do not need to copy those implementation targets into each website. The tool names use `bibliometrics_*` even though factory Make targets retain `metrics-*` for backwards compatibility.
+
+`distribution_doctor` findings always include `code`, `severity`, `expected`, `actual`, and `remediation`. Missing factory assets in a direct wheel install produce healthy limited wheel mode, not a false failure. When Docker checks are requested, doctor uses only `docker version` and `docker image inspect`; it does not pull, build, start, or remove anything.
 
 Manual PDF publication is a local workspace operation: it copies reviewed artefacts from `tmp/manual-pdf/` to configured paths such as `assets/pdf/` and `assets/img/`. It never commits, pushes, creates releases, or writes outside the consumer workspace. Run `manual_source_quality_check`, `manual_editorial_quality_check`, `manual_pdf_status`, `manual_pdf_build`, and a `manual_pdf_publish` dry-run before calling `manual_pdf_publish(dry_run=false, confirm_publish=true)`.
 
 ## New Site Initialization
 
-`new_web` is intended for empty or nearly-empty website repositories. It creates common runtime files, profile-specific configuration, localized home pages, and the content paths required by the selected profile. All scaffold assets are shipped inside the `unaltraweb_mcp` Python package and MCP Docker image; environment variables, sibling checkouts, and arbitrary template paths are not consulted.
+`new_web` is intended for empty or nearly-empty website repositories. It creates common runtime files, profile-specific configuration, localized home pages, the content paths required by the selected profile, and `.unaltraweb/scaffold.json`. All scaffold assets are shipped inside the `unaltraweb_mcp` Python package and MCP Docker image; environment variables, sibling checkouts, and arbitrary template paths are not consulted.
 
 The `unaltremanual` scaffold also creates `context/writing-profile.md` with a usable default editorial policy. Customize that local file for the manual's audience, voice, terminology, evidence policy, language workflow, and review requirements.
 
 It sets `lang`, `default_lang`, and `languages` so a new site has an explicit source language from the first commit. The default is a single English home page; every configured language gets a localized home-page source and route.
 
-Before writing, it validates every managed path, rejects destination symlinks, and compares existing files with the complete rendered scaffold. Identical files make repeated calls idempotent. Any differing file or file/directory collision detected during preflight aborts the whole operation before website files are written. Descriptor-relative, no-clobber writes and a final descriptor-relative content check prevent raced paths from being followed or overwritten; overwrite mode is not available.
+Before writing, it validates every managed path, rejects destination symlinks, and compares existing files with the complete rendered scaffold through bounded regular-file reads. Identical files make repeated calls idempotent. Any differing file or file/directory collision detected during preflight aborts the whole operation before website files are written. Descriptor-relative, no-clobber writes and a final descriptor-relative content check prevent raced paths from being followed or overwritten; overwrite mode is not available. The baseline manifest is created after every other scaffold file.
+
+The baseline records only `.gitignore`, `Makefile`, `Gemfile`, `Gemfile.lock`, and `.github/workflows/deploy.yml`. `scaffold_sync` updates one of these only while its bytes still match the recorded baseline, creates a newly managed path only when it is absent, and reports local edits or deletions as conflicts. Any conflict prevents every apply. It does not delete retired managed paths and never changes config, seed content, bibliography, data, or assets. A real synchronization requires `dry_run=false` and `confirm_sync=true`; adopted and unchanged files are included in the final rechecks around the manifest-last commit.
 
 Each scaffold is already reduced to one profile, so `profile_prune_plan` is not part of new-site creation. The prune rule remains available for existing mixed-profile sites.
+
+## Constrained Source Management
+
+The source tools are not generic filesystem operations. Their complete write scope is `_config.yml`; Markdown/HTML under the known content collections; YAML, JSON, or CSV below `_data/`; and Markdown below `context/`. Workflows, Makefiles, Gemfiles, layouts, includes, plugins, Sass, bibliography, binary assets, generated paths, symlinks, directories, absolute paths, and traversal are outside this API.
+
+All operations use project-confined descriptor-relative no-follow traversal. Nonblocking open rejects FIFOs/devices before reading, size is checked before allocation, and files/proposed content are limited to 1 MiB. Text must be UTF-8 without NUL bytes; YAML and JSON reject duplicate keys, and JSON rejects non-finite numbers. Reads return SHA-256. Existing writes require that exact digest; new writes require `create_only=true`. Apply takes an advisory parent lock, moves the expected object to a private backup, verifies content and identity before and after publication, and restores the backup when a final-window edit is detected. Deletes use the equivalent verified tombstone flow. `_config.yml` is never deletable.
 
 ## Language And Translation Discipline
 
@@ -113,13 +140,15 @@ Translations are a pre-publication task. They should preserve `ref`, citations, 
 
 ## Docker Runtime And Preview
 
-`make mcp-build` builds `ghcr.io/dosquartsdedocs/unaltraweb:0.3.0` and then `ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0` locally. `make mcp-smoke` runs a real MCP client/server stdio exchange, compiles a temporary minimal site, and exercises preview start/status/stop. `mcp-stdio` remains dormant until a client launches it.
+`make mcp-build` builds `ghcr.io/dosquartsdedocs/unaltraweb:0.3.0` and then `ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0` locally. `make mcp-smoke` runs a real MCP client/server stdio exchange, compiles a temporary minimal site, and exercises preview start/status/stop. `mcp-stdio` remains dormant until a client launches it; dependency preparation never invokes it.
 
-Run `site_check` and resolve any blocking validation result before compiling. `build_site` then reuses the active MCP container and the consumer's `build-native` target. This is intentionally different from the consumer's normal host-side `make build`, which starts a Jekyll container and would create a nested runtime when called from MCP.
+Run `site_doctor` and `site_check`, then resolve any blocking validation result before compiling. `build_site` reuses the active MCP container and the consumer's `build-native` target, and runs the local HTML audit after a successful Jekyll process. The generated `test-native` target also runs `html_audit`. This is intentionally different from the consumer's normal host-side `make build`, which starts a Jekyll container and would create a nested runtime when called from MCP.
 
-A preview must outlive one MCP tool invocation, so it runs in a separate container made from the same MCP/Jekyll image. Its deterministic name is derived from the canonical host project path and it carries the factory, role, and project labels. Starting an already-running preview probes it again instead of creating a duplicate; changing its port or profile requires stopping it first. Stop and cleanup operations verify ownership labels before removing anything.
+Make delegation and feasible Docker control calls use one bounded subprocess runner. Status and control commands have short deadlines, builds/renders have target-specific longer deadlines, timeout terminates the process group and returns code `124`, and retained stdout/stderr is capped with explicit truncation fields. Factory commands that promise JSON fail closed when output is empty, malformed, non-object, non-finite, or truncated. Computation, capture, and PDF containers carry factory, worker-role, project, and invocation-token labels plus cidfiles; after timeout cleanup selects all four labels and cannot remove unrelated containers.
 
-`preview_status.url` is the browser URL published on host loopback. `preview_status.internal_url` is reachable from the MCP container and can be passed to `http_check`. `make mcp-down` force-removes all and only containers selected by `label=io.context.mcp-factory=unaltraweb`; it does not delete images or touch ordinary site containers.
+A preview must outlive one MCP tool invocation, so it runs in a separate container made from the same MCP/Jekyll image. Its deterministic name is derived from the canonical host project path and it carries the factory, role, and project labels. Starting an already-running preview probes it again instead of creating a duplicate; changing its port or profile requires stopping it first. Stdio session containers intentionally have Docker-generated names so independent clients can run simultaneously, but carry the same stable project ID and labels as previews and capture resources. Stop and cleanup operations select ownership labels before removing anything.
+
+`preview_status.url` is the browser URL published on host loopback. `preview_status.internal_url` is informational; callers do not pass it to `http_check`. That tool verifies preview ownership, derives the exact container-internal HTTP origin, disables environment proxies, accepts at most 20 local paths within a bounded timeout and response-read budget, and rejects absolute URLs, protocol-relative forms, traversal, fragments, hostile characters, non-2xx results, and redirects. A private probe helper uses the same no-redirect behavior for preview readiness. `make mcp-down PROJECT=/canonical/consumer/path` removes containers and networks selected by both `io.context.mcp-factory=unaltraweb` and the stable project label derived from that canonical path. `make mcp-down-all` is the explicit maintainer cleanup for every resource carrying the factory label. Neither target deletes images or touches unlabelled resources.
 
 The Docker socket gives the MCP container authority equivalent to the host Docker user. Enable this factory only for trusted unaltraweb repositories and trusted local images; project Makefiles execute as part of explicit build and authoring tools.
 

--- a/docs/agents/quarto-computation-adoption.md
+++ b/docs/agents/quarto-computation-adoption.md
@@ -56,7 +56,7 @@ engines:
   python:
     dockerfile: Dockerfile.compute-python
     context: .
-    base_image: ghcr.io/dosquartsdedocs/unaltraweb-compute-python:main
+    base_image: ghcr.io/dosquartsdedocs/unaltraweb-compute-python:0.3.0
     local_image: tigit-compute-python:local
     lockfiles:
       - requirements-compute.txt

--- a/lib/unaltraweb/version.rb
+++ b/lib/unaltraweb/version.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "json"
+
 module Unaltraweb
-  VERSION = "0.3.0" unless const_defined?(:VERSION, false)
+  contract_path = File.expand_path("../../src/unaltraweb_mcp/component-contract.json", __dir__)
+  VERSION = JSON.parse(File.read(contract_path)).fetch("release").fetch("version") unless const_defined?(:VERSION, false)
 end

--- a/mcp-factory.yml
+++ b/mcp-factory.yml
@@ -1,8 +1,9 @@
----
+schema_version: 1
 name: unaltraweb
 kind: codex-mcp-factory
 version: 0.3.0
 description: Reusable Jekyll website factory with package-owned site creation and MCP tooling for content, profiles, captures, visualizations, bibliography, bibliometrics, and build checks.
+repository: https://github.com/dosquartsdedocs/unaltraweb
 install_scope: user
 workspace_rule:
   consumer_root: .
@@ -25,11 +26,9 @@ workspace_rule:
     - assets
     - context
     - .github/workflows
+    - .unaltraweb/scaffold.json
   source_paths:
     - _config.yml
-    - Gemfile
-    - Gemfile.lock
-    - Makefile
     - _pages
     - _posts
     - _news
@@ -37,12 +36,10 @@ workspace_rule:
     - _outputs
     - _chapters
     - _documentation
-    - _bibliography
+    - _books
+    - _theses
     - _data
-    - assets
     - context
-    - .github/workflows
-    - .vegavisuals.yml
   generated_paths:
     - _site
     - tmp
@@ -60,25 +57,21 @@ runtime:
 transport:
   type: stdio
   command:
-    - /bin/sh
-    - -c
-    - 'exec env PROJECT="$PWD" make --silent --no-print-directory -C "${factoryRoot}" mcp-stdio'
+    - make
+    - -C
+    - '${factoryRoot}'
+    - mcp-stdio
+    - 'PROJECT=${workspaceFolder}'
 commands:
   build:
     - make
     - mcp-build
-  init:
-    - make
-    - mcp-init
   check:
     - make
     - mcp-check
   smoke:
     - make
     - mcp-smoke
-  down:
-    - make
-    - mcp-down
 discovery:
   suggested_scan_roots:
     - ~/git
@@ -87,11 +80,18 @@ discovery:
     - The on-demand stdio launcher mounts the current workspace into the Dockerized MCP runtime.
     - Site builds execute inside the MCP runtime; previews use one labelled container per consumer project.
     - Durable website state belongs in versioned site files, not in chat history.
+release:
+  default: v0.3.0
+contracts:
+  component_bom: 1
+  distribution_doctor: 1
 mcp:
   server_name: unaltraweb
   transport: stdio
   resources:
+    - web://distribution
     - web://site-context
+    - web://site-doctor
     - web://new-web-scaffolds
     - web://starter-templates
     - web://profile-contract
@@ -109,12 +109,18 @@ mcp:
     - web://build-health
     - web://prompts
   required_tools:
+    - distribution_doctor
     - new_web
     - initialize_site
     - starter_templates
     - site_context
+    - site_doctor
     - detect_site
     - site_check
+    - site_source_read
+    - site_source_write
+    - site_source_delete
+    - scaffold_sync
     - profile_check
     - manual_source_quality_check
     - manual_editorial_quality_check
@@ -143,6 +149,7 @@ mcp:
     - bibliometrics_update
     - build_site
     - build_health
+    - html_audit
     - preview_start
     - preview_status
     - preview_stop
@@ -153,12 +160,16 @@ mcp_dependencies:
     required: true
     install: true
     build: true
-    init: true
-    remote: git@github.com:dosquartsdedocs/diavisuals.git
+    init: false
+    remote: https://github.com/dosquartsdedocs/diavisuals.git
     package: diavisuals
+    version: 0.3.1
+    release: v0.3.1
+    release_status: pending
     extras:
       - mcp
     required_tools:
+      - project_check
       - render_diagram
       - render_diagram_text
     suggested_path: ../diavisuals
@@ -168,9 +179,12 @@ mcp_dependencies:
     required: true
     install: true
     build: true
-    init: true
-    remote: git@github.com:dosquartsdedocs/vegavisuals.git
+    init: false
+    remote: https://github.com/dosquartsdedocs/vegavisuals.git
     package: vegavisuals
+    version: 0.3.1
+    release: v0.3.1
+    release_status: pending
     extras:
       - mcp
     required_tools:
@@ -181,4 +195,3 @@ mcp_dependencies:
       - render_visualizations
     suggested_path: ../vegavisuals
     reason: Vega-Lite and Vega validation, rendering, themes, and freshness are owned by vegavisuals.
----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "bibtexparser>=1.4,<2",
   "PyYAML>=6,<7",
   "requests>=2.31,<3",
+  "tomli>=2,<3; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unaltraweb-mcp"
-version = "0.3.0"
+dynamic = ["version"]
 description = "MCP control plane for unaltraweb website workspaces"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -27,11 +27,16 @@ unaltraweb-mcp = "unaltraweb_mcp.cli:main"
 [tool.setuptools]
 package-dir = {"" = "src"}
 
+[tool.setuptools.dynamic]
+version = {attr = "unaltraweb_mcp.__version__"}
+
 [tool.setuptools.packages.find]
 where = ["src"]
 
 [tool.setuptools.package-data]
 unaltraweb_mcp = [
+  "component-contract.json",
+  "component-contract.schema.json",
   "scaffolds/common/*",
   "scaffolds/common/.gitignore",
   "scaffolds/common/.github/workflows/*.yml",

--- a/scripts/computations/render.py
+++ b/scripts/computations/render.py
@@ -31,8 +31,8 @@ LOCK_PATH = Path(".unaltraweb/computations.lock.json")
 SUPPORTED_SUFFIXES = {".qmd", ".rmd", ".r", ".py", ".ipynb"}
 GENERATED_MEDIA_SUFFIXES = {".gif", ".jpeg", ".jpg", ".pdf", ".png", ".svg", ".webp"}
 DEFAULT_IMAGES = {
-    "python": "ghcr.io/dosquartsdedocs/unaltraweb-compute-python:main",
-    "r": "ghcr.io/dosquartsdedocs/unaltraweb-compute-r:main",
+    "python": "ghcr.io/dosquartsdedocs/unaltraweb-compute-python:0.3.0",
+    "r": "ghcr.io/dosquartsdedocs/unaltraweb-compute-r:0.3.0",
 }
 ENGINE_ENV = {"python": "COMPUTE_PYTHON_IMAGE", "r": "COMPUTE_R_IMAGE"}
 FRONT_MATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n?", re.DOTALL)

--- a/scripts/test_gem_build.py
+++ b/scripts/test_gem_build.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Build the gem without network access and inspect its packaged contract files."""
+
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = json.loads((ROOT / "src/unaltraweb_mcp/component-contract.json").read_text(encoding="utf-8"))
+RUNTIME_IMAGE = str(CONTRACT["components"]["runtime"]["reference"])
+
+
+def run(command: list[str], *, cwd: Path = ROOT) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(f"Command failed: {' '.join(command)}\n{completed.stdout}\n{completed.stderr}")
+    return completed
+
+
+def build(output: Path) -> str:
+    if shutil.which("ruby") and shutil.which("gem"):
+        run(["gem", "build", "unaltraweb.gemspec", "--output", str(output)])
+        return "local-ruby"
+    if not shutil.which("docker"):
+        raise RuntimeError("Gem smoke requires local RubyGems or Docker with the selected runtime image.")
+    inspected = subprocess.run(
+        ["docker", "image", "inspect", RUNTIME_IMAGE],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if inspected.returncode != 0:
+        raise RuntimeError(f"Gem smoke requires the already-local runtime image {RUNTIME_IMAGE}; it never pulls implicitly.")
+    run([
+        "docker", "run", "--rm", "--network", "none",
+        "-v", f"{ROOT}:/repo:ro", "-v", f"{output.parent}:/out:rw", "-w", "/repo",
+        RUNTIME_IMAGE, "gem", "build", "unaltraweb.gemspec", "--output", f"/out/{output.name}",
+    ])
+    return "docker-runtime"
+
+
+def inspect_gem(path: Path) -> None:
+    with tarfile.open(path, mode="r") as package:
+        data_member = package.extractfile("data.tar.gz")
+        if data_member is None:
+            raise RuntimeError("Built gem has no data.tar.gz payload.")
+        with tarfile.open(fileobj=io.BytesIO(data_member.read()), mode="r:gz") as payload:
+            names = set(payload.getnames())
+    required = {
+        "lib/unaltraweb/version.rb",
+        "src/unaltraweb_mcp/component-contract.json",
+        "src/unaltraweb_mcp/component-contract.schema.json",
+    }
+    missing = sorted(required - names)
+    if missing:
+        raise RuntimeError(f"Built gem is missing required files: {missing}")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="unaltraweb-gem-") as raw_temp:
+        output = Path(raw_temp) / "unaltraweb.gem"
+        runner = build(output)
+        inspect_gem(output)
+        print(json.dumps({"ok": True, "runner": runner, "gem": output.name}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_wheel_install.py
+++ b/scripts/test_wheel_install.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Build and exercise a clean, factory-free unaltraweb-mcp wheel install."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import venv
+import zipfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(command: list[str], *, cwd: Path, env: dict[str, str] | None = None, expected: int = 0) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(command, cwd=cwd, env=env, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if completed.returncode != expected:
+        raise RuntimeError(
+            f"Command returned {completed.returncode}, expected {expected}: {' '.join(command)}\n{completed.stdout}\n{completed.stderr}"
+        )
+    return completed
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="unaltraweb-wheel-") as raw_temp:
+        temp = Path(raw_temp)
+        wheel_dir = temp / "dist"
+        wheel_dir.mkdir()
+        env = os.environ.copy()
+        env["PIP_NO_INDEX"] = "1"
+        run(
+            [sys.executable, "-m", "pip", "wheel", ".", "--no-deps", "--no-build-isolation", "--wheel-dir", str(wheel_dir)],
+            cwd=ROOT,
+            env=env,
+        )
+        wheels = list(wheel_dir.glob("unaltraweb_mcp-*.whl"))
+        if len(wheels) != 1:
+            raise RuntimeError(f"Expected one wheel, found: {wheels}")
+        with zipfile.ZipFile(wheels[0]) as archive:
+            names = archive.namelist()
+        forbidden_roots = {"docs", "scripts", "_layouts", "_includes", "_sass"}
+        leaked = []
+        for name in names:
+            parts = Path(name).parts
+            if not parts or parts[0] != "unaltraweb_mcp":
+                continue
+            package_parts = parts[1:]
+            if package_parts and (package_parts[0] in forbidden_roots or package_parts[0] in {"mcp-factory.yml", "Dockerfile", "Makefile"}):
+                leaked.append(name)
+        if leaked:
+            raise RuntimeError(f"Factory assets leaked into wheel: {leaked}")
+        required = [
+            "unaltraweb_mcp/component-contract.json",
+            "unaltraweb_mcp/component-contract.schema.json",
+            "unaltraweb_mcp/scaffolds/common/Makefile.tmpl",
+        ]
+        missing = [name for name in required if name not in names]
+        if missing:
+            raise RuntimeError(f"Wheel is missing modular package assets: {missing}")
+
+        environment = temp / "venv"
+        venv.EnvBuilder(with_pip=True).create(environment)
+        python = environment / "bin/python"
+        cli = environment / "bin/unaltraweb-mcp"
+        run([str(python), "-m", "pip", "install", "--no-deps", str(wheels[0])], cwd=temp, env=env)
+        version = run([str(cli), "version"], cwd=temp).stdout.strip()
+        doctor = json.loads(run([str(cli), "doctor"], cwd=temp).stdout)
+        if not doctor["ok"] or doctor["mode"] != "wheel" or not doctor["limited"]:
+            raise RuntimeError(f"Unexpected clean wheel doctor result: {doctor}")
+
+        site = temp / "site"
+        created = json.loads(run([str(cli), "--project", str(site), "new-web", "--site-profile", "unaltredocs"], cwd=temp).stdout)
+        if not created["ok"]:
+            raise RuntimeError(f"new-web failed from clean wheel: {created}")
+        if not (site / ".unaltraweb/scaffold.json").is_file():
+            raise RuntimeError("new-web did not install the package scaffold baseline")
+        detected = json.loads(run([str(cli), "--project", str(site), "mcp", "detect-site"], cwd=temp).stdout)
+        if not detected["is_unaltraweb_site"]:
+            raise RuntimeError(f"package-only inspection failed from clean wheel: {detected}")
+        project_doctor = json.loads(run([str(cli), "doctor", "--project", str(site)], cwd=temp).stdout)
+        if not project_doctor["ok"] or project_doctor["project"]["profile"] != "unaltredocs":
+            raise RuntimeError(f"project doctor failed from clean wheel: {project_doctor}")
+        site_doctor = json.loads(run([str(cli), "--project", str(site), "mcp", "site-doctor"], cwd=temp).stdout)
+        if not site_doctor["ok"] or not site_doctor["offline"]:
+            raise RuntimeError(f"site doctor failed from clean wheel: {site_doctor}")
+        source = json.loads(run([str(cli), "--project", str(site), "mcp", "site-source-read", "--path", "_pages/en/index.md"], cwd=temp).stdout)
+        source_dry_run = json.loads(run([
+            str(cli), "--project", str(site), "mcp", "site-source-write",
+            "--path", "_pages/en/index.md", "--content", source["content"] + "\nWheel source test.\n",
+            "--expected-sha256", source["sha256"],
+        ], cwd=temp).stdout)
+        if not source_dry_run["dry_run"] or (site / "_pages/en/index.md").read_text(encoding="utf-8") != source["content"]:
+            raise RuntimeError(f"wheel source dry-run mutated content: {source_dry_run}")
+        scaffold = json.loads(run([str(cli), "--project", str(site), "mcp", "scaffold-sync"], cwd=temp).stdout)
+        if not scaffold["ok"] or not scaffold["dry_run"]:
+            raise RuntimeError(f"wheel scaffold sync dry-run failed: {scaffold}")
+
+        factory_error = run([str(cli), "--project", str(site), "mcp", "prompts"], cwd=temp, expected=1)
+        if "requires the unaltraweb factory checkout" not in factory_error.stderr:
+            raise RuntimeError(f"Factory-required command did not fail clearly: {factory_error.stderr}")
+        print(json.dumps({"ok": True, "version": version, "wheel": wheels[0].name, "mode": doctor["mode"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/unaltraweb-mcp-bootstrap.sh
+++ b/scripts/unaltraweb-mcp-bootstrap.sh
@@ -48,9 +48,8 @@ fi
 project="$(CDPATH= cd -- "$project" && pwd -P)"
 owner="${UNALTRAWEB_PROJECT_USER:-$(id -u):$(id -g)}"
 docker_socket="${UNALTRAWEB_DOCKER_SOCKET:-/var/run/docker.sock}"
-checksum="$(printf '%s' "$project" | cksum)"
-project_id="${checksum%% *}"
-container_name="unaltraweb-mcp-$project_id"
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)"
+project_id="$(/bin/sh "$script_dir/unaltraweb-mcp-project-id.sh" "$project")"
 
 if ! resolved_image="$(docker image inspect --format '{{.Id}}' "$image" 2>/dev/null)"; then
   docker pull "$image" >/dev/null
@@ -58,7 +57,6 @@ if ! resolved_image="$(docker image inspect --format '{{.Id}}' "$image" 2>/dev/n
 fi
 
 set -- docker run --rm -i \
-  --name "$container_name" \
   --label io.context.mcp-factory=unaltraweb \
   --label io.context.mcp-role=stdio \
   --label "io.context.mcp-project=$project_id" \

--- a/scripts/unaltraweb-mcp-project-id.sh
+++ b/scripts/unaltraweb-mcp-project-id.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+project="${1:-${UNALTRAWEB_PROJECT:-${PROJECT:-$PWD}}}"
+
+if [ "$#" -gt 1 ]; then
+  printf '%s\n' 'Usage: unaltraweb-mcp-project-id [PROJECT]' >&2
+  exit 2
+fi
+if [ ! -d "$project" ]; then
+  printf 'Project directory not found: %s\n' "$project" >&2
+  exit 1
+fi
+
+project="$(CDPATH= cd -- "$project" && pwd -P)"
+if command -v sha256sum >/dev/null 2>&1; then
+  checksum="$(printf '%s' "$project" | sha256sum)"
+elif command -v shasum >/dev/null 2>&1; then
+  checksum="$(printf '%s' "$project" | shasum -a 256)"
+else
+  printf '%s\n' 'sha256sum or shasum is required to identify the project.' >&2
+  exit 1
+fi
+checksum="${checksum%% *}"
+printf '%.16s\n' "$checksum"

--- a/scripts/validate_distribution.py
+++ b/scripts/validate_distribution.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Validate release parity, component pins, and the modular wheel boundary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from unaltraweb_mcp import __version__  # noqa: E402
+from unaltraweb_mcp.cli import (  # noqa: E402
+    FACTORY_REQUIRED_COMMANDS,
+    FACTORY_REQUIRED_MCP_COMMANDS,
+    PACKAGE_ONLY_COMMANDS,
+    PACKAGE_ONLY_MCP_COMMANDS,
+)
+from unaltraweb_mcp.distribution import (  # noqa: E402
+    component_contract_semantic_errors,
+    component_reference,
+    distribution_contract,
+    is_mutable_reference,
+    validate_component_contract,
+)
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        import yaml  # type: ignore
+
+        class UniqueKeyLoader(yaml.SafeLoader):
+            pass
+
+        def construct_mapping(loader, node, deep=False):
+            mapping: dict[Any, Any] = {}
+            for key_node, value_node in node.value:
+                key = loader.construct_object(key_node, deep=deep)
+                if key in mapping:
+                    raise ValueError(f"duplicate YAML key: {key}")
+                mapping[key] = loader.construct_object(value_node, deep=deep)
+            return mapping
+
+        UniqueKeyLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping)
+        value = yaml.load(path.read_text(encoding="utf-8"), Loader=UniqueKeyLoader)
+    except Exception as exc:
+        raise RuntimeError(f"Could not read {path}: {exc}") from exc
+    return value if isinstance(value, dict) else {}
+
+
+def make_value(path: Path, variable: str) -> str:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(rf"(?m)^{re.escape(variable)}\s*\?[:+]?=\s*([^\s#]+)", text)
+    return match.group(1).strip('"\'') if match else ""
+
+
+def validate(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    contract = distribution_contract()
+    version = str(contract["release"]["version"])
+    required_components = {
+        "gem", "wheel", "runtime", "mcp", "compute_python", "compute_r", "web_capture", "manual_pdf", "diavisuals", "vegavisuals"
+    }
+    if contract.get("schema_version") != 1:
+        errors.append("component contract schema_version must be 1")
+    if set(contract.get("components", {})) != required_components:
+        errors.append("component contract inventory is incomplete")
+    if __version__ != version:
+        errors.append(f"wheel version {__version__} != contract version {version}")
+    for component_id in ["gem", "wheel", "runtime", "mcp", "compute_python", "compute_r", "web_capture", "manual_pdf"]:
+        if str(contract["components"][component_id]["version"]) != version:
+            errors.append(f"{component_id} version does not match release {version}")
+    included = {name for name, item in contract["components"].items() if item["included_in_wheel"]}
+    if included != {"wheel"}:
+        errors.append(f"wheel must not bundle external components: {sorted(included)}")
+    wheel_contract = contract["wheel_contract"]
+    if set(wheel_contract["package_only_commands"]) != PACKAGE_ONLY_COMMANDS:
+        errors.append("wheel package-only command inventory does not match the CLI")
+    if set(wheel_contract["factory_required_commands"]) != FACTORY_REQUIRED_COMMANDS:
+        errors.append("wheel factory-required command inventory does not match the CLI")
+    if set(wheel_contract["package_only_mcp"]) != PACKAGE_ONLY_MCP_COMMANDS:
+        errors.append("wheel package-only MCP inventory does not match the CLI")
+    if set(wheel_contract["factory_required_mcp"]) != FACTORY_REQUIRED_MCP_COMMANDS:
+        errors.append("wheel factory-required MCP inventory does not match the CLI")
+
+    schema = json.loads((root / "src/unaltraweb_mcp/component-contract.schema.json").read_text(encoding="utf-8"))
+    try:
+        validate_component_contract(contract, schema)
+    except RuntimeError as exc:
+        errors.append(f"component contract schema validation failed: {exc}")
+    errors.extend(f"component contract semantic validation failed: {error}" for error in component_contract_semantic_errors(contract))
+    if schema.get("properties", {}).get("schema_version", {}).get("const") != 1:
+        errors.append("component contract schema does not select version 1")
+
+    pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    project = pyproject.get("project", {})
+    if "version" in project or project.get("dynamic") != ["version"]:
+        errors.append("pyproject version must be derived from the package component contract")
+    if pyproject.get("tool", {}).get("setuptools", {}).get("dynamic", {}).get("version", {}).get("attr") != "unaltraweb_mcp.__version__":
+        errors.append("setuptools dynamic version is not wired to unaltraweb_mcp.__version__")
+    ruby_version_source = (root / "lib/unaltraweb/version.rb").read_text(encoding="utf-8")
+    if "component-contract.json" not in ruby_version_source or re.search(r'VERSION\s*=\s*["\']\d', ruby_version_source):
+        errors.append("gem version must be derived from the package component contract")
+    gemspec = (root / "unaltraweb.gemspec").read_text(encoding="utf-8")
+    if 'spec.required_ruby_version = ">= 3.2"' not in gemspec:
+        errors.append("gemspec Ruby requirement must support the Bundler 4 scaffold lock")
+    for asset in ["component-contract.json", "component-contract.schema.json"]:
+        if gemspec.count(f'"src/unaltraweb_mcp/{asset}"') < 2:
+            errors.append(f"gemspec must discover and select {asset}")
+
+    manifest = load_yaml(root / "mcp-factory.yml")
+    if str(manifest.get("version")) != version:
+        errors.append("mcp-factory.yml version does not match the component contract")
+    if str(manifest.get("release", {}).get("default")) != contract["release"]["tag"]:
+        errors.append("mcp-factory.yml release.default does not match the component contract")
+    if str(manifest.get("runtime", {}).get("image")) != component_reference("mcp"):
+        errors.append("mcp-factory.yml runtime image does not match the component contract")
+
+    dependencies = {
+        str(item.get("name")): item
+        for item in manifest.get("mcp_dependencies", [])
+        if isinstance(item, dict)
+    }
+    for component_id in ["diavisuals", "vegavisuals"]:
+        expected = contract["components"][component_id]
+        actual = dependencies.get(component_id, {})
+        expected_remote = expected["repository"] + ".git"
+        for key, selected in [
+            ("version", expected["version"]),
+            ("release", expected["release"]),
+            ("release_status", expected["release_status"]),
+            ("remote", expected_remote),
+        ]:
+            if str(actual.get(key) or "") != selected:
+                errors.append(f"{component_id} {key} does not match the selected companion release")
+        if not str(actual.get("remote") or "").startswith("https://"):
+            errors.append(f"{component_id} remote must use HTTPS")
+
+    make_pins = {
+        "MCP_RUNTIME_IMAGE": "runtime",
+        "MCP_IMAGE": "mcp",
+        "WEB_CAPTURE_IMAGE": "web_capture",
+        "DOCKER_IMAGE": "runtime",
+        "MANUAL_PDF_IMAGE": "manual_pdf",
+    }
+    for variable, component_id in make_pins.items():
+        actual = make_value(root / "Makefile", variable)
+        expected = component_reference(component_id)
+        if actual != expected:
+            errors.append(f"Makefile {variable}={actual or 'missing'} != {expected}")
+
+    pinned_text = {
+        "scripts/computations/render.py": [component_reference("compute_python"), component_reference("compute_r")],
+        "scripts/web_captures/render.py": [component_reference("web_capture")],
+        "scripts/unaltraweb-mcp-bootstrap.sh": [component_reference("mcp")],
+        "Dockerfile.mcp": [component_reference("runtime")],
+    }
+    for relative, references in pinned_text.items():
+        text = (root / relative).read_text(encoding="utf-8")
+        for reference in references:
+            if reference not in text:
+                errors.append(f"{relative} does not contain selected reference {reference}")
+        if re.search(r"ghcr\.io/dosquartsdedocs/[^\s\"']+:(?:main|latest)\b", text):
+            errors.append(f"{relative} contains a mutable production default")
+
+    scaffold_templates = {
+        "Gemfile.tmpl": "__GEM_VERSION__",
+        "Gemfile.lock.tmpl": "__GEM_VERSION__",
+        "Makefile.tmpl": "__MCP_IMAGE__",
+    }
+    for name, token in scaffold_templates.items():
+        text = (root / "src/unaltraweb_mcp/scaffolds/common" / name).read_text(encoding="utf-8")
+        if token not in text:
+            errors.append(f"scaffold {name} must derive its release pin from the component contract")
+
+    release_references = [
+        item["reference"]
+        for item in contract["components"].values()
+        if item["kind"] in {"container", "companion"}
+    ]
+    for reference in release_references:
+        if is_mutable_reference(str(reference)):
+            errors.append(f"component contract contains a mutable release reference: {reference}")
+
+    package_root = root / "src/unaltraweb_mcp"
+    forbidden = ["mcp-factory.yml", "Dockerfile", "Makefile", "docs", "scripts", "_layouts", "_includes", "_sass"]
+    for name in forbidden:
+        if (package_root / name).exists():
+            errors.append(f"wheel boundary contains factory asset: {name}")
+    if not (package_root / "scaffolds").is_dir():
+        errors.append("wheel boundary is missing package-owned scaffolds")
+
+    ruby = shutil.which("ruby")
+    if ruby:
+        completed = subprocess.run(
+            [ruby, "-Ilib", "-runaltraweb/version", "-e", "print Unaltraweb::VERSION"],
+            cwd=root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if completed.returncode != 0 or completed.stdout != version:
+            errors.append(f"gem version parity failed: {completed.stderr.strip() or completed.stdout}")
+    return errors
+
+
+def publish_ref_errors(
+    contract: dict[str, Any],
+    *,
+    ref_type: str,
+    ref_name: str,
+    default_branch: str,
+    component_ids: list[str],
+) -> list[str]:
+    errors: list[str] = []
+    release = contract.get("release", {})
+    version = str(release.get("version") or "")
+    release_tag = str(release.get("tag") or "")
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version) or release_tag != f"v{version}":
+        errors.append("distribution release must use matching X.Y.Z and vX.Y.Z values")
+
+    components = contract.get("components", {})
+    for component_id in component_ids:
+        component = components.get(component_id)
+        if not isinstance(component, dict):
+            errors.append(f"unknown publish component: {component_id}")
+            continue
+        if str(component.get("version") or "") != version:
+            errors.append(f"{component_id} publish version does not match distribution release {version}")
+        if str(component.get("release") or "") != release_tag:
+            errors.append(f"{component_id} publish tag does not match distribution release {release_tag}")
+
+    if ref_type == "branch" and ref_name == default_branch and default_branch:
+        return errors
+    if ref_type == "tag" and ref_name == release_tag:
+        return errors
+    errors.append(f"publish ref must be the default branch {default_branch or '<unset>'} or exact release tag {release_tag or '<unset>'}")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--require-release-ready",
+        action="store_true",
+        help="Fail when a selected external component release is pending or unavailable.",
+    )
+    parser.add_argument(
+        "--validate-publish-ref",
+        action="store_true",
+        help="Require the GitHub ref to be the default branch or the exact distribution release tag.",
+    )
+    parser.add_argument(
+        "--components",
+        default="",
+        help="Comma-separated component IDs whose versions and release tags must match before publication.",
+    )
+    args = parser.parse_args(argv)
+    errors = validate()
+    contract = distribution_contract()
+    if args.validate_publish_ref:
+        component_ids = [item.strip() for item in args.components.split(",") if item.strip()]
+        if not component_ids:
+            errors.append("--validate-publish-ref requires at least one --components value")
+        errors.extend(publish_ref_errors(
+            contract,
+            ref_type=os.environ.get("GITHUB_REF_TYPE", ""),
+            ref_name=os.environ.get("GITHUB_REF_NAME", ""),
+            default_branch=os.environ.get("GITHUB_DEFAULT_BRANCH", ""),
+            component_ids=component_ids,
+        ))
+    pending = sorted(
+        component_id for component_id, selected in contract["components"].items()
+        if selected["release_status"] == "pending"
+    )
+    unavailable = sorted(
+        component_id for component_id, selected in contract["components"].items()
+        if selected["release_status"] == "unavailable"
+    )
+    print(json.dumps({
+        "ok": not errors,
+        "release_ready": not errors and not pending and not unavailable,
+        "errors": errors,
+        "pending_releases": pending,
+        "unavailable_releases": unavailable,
+    }, indent=2, sort_keys=True))
+    return 1 if errors else (2 if args.require_release_ready and (pending or unavailable) else 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_distribution.py
+++ b/scripts/validate_distribution.py
@@ -10,9 +10,13 @@ import re
 import shutil
 import subprocess
 import sys
-import tomllib
 from pathlib import Path
 from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 package dependency.
+    import tomli as tomllib
 
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/scripts/validate_workflows.py
+++ b/scripts/validate_workflows.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Validate GitHub Actions syntax, immutable pins, and publication gates."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_ROOT = ROOT / ".github/workflows"
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+REVIEWED_ACTIONS = {
+    "actions/checkout": "11d5960a326750d5838078e36cf38b85af677262",
+    "actions/configure-pages": "983d7736d9b0ae728b81ab479565c72886d7745b",
+    "actions/deploy-pages": "d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e",
+    "actions/setup-python": "a26af69be951a213d495a4c3e4e4022e16d87065",
+    "actions/upload-artifact": "ea165f8d65b6e75b540449e92b4886f43607fa02",
+    "actions/upload-pages-artifact": "56afc609e74202658d3ffba0e8f6dda462b719fa",
+    "docker/build-push-action": "10e90e3645eae34f1e60eeb005ba3a3d33f178e8",
+    "docker/login-action": "c94ce9fb468520275223c153574b00df6fe4bcc9",
+    "docker/metadata-action": "c299e40c65443455700f0fdfc63efafe5b349051",
+    "docker/setup-buildx-action": "8d2750c68a42422c14e847fe6c8ac0403b4cbd6f",
+    "ruby/setup-ruby": "95ef2b042f9d7a56d8268cba8559e2842e2ad01b",
+}
+IMAGE_WORKFLOWS = {
+    "compute-images.yml",
+    "docker-image.yml",
+    "project-compute-image.yml",
+    "web-capture-image.yml",
+}
+FULLY_PINNED_WORKFLOWS = IMAGE_WORKFLOWS | {"ci.yml", "package-prepare.yml"}
+
+
+class WorkflowLoader(yaml.SafeLoader):
+    pass
+
+
+WorkflowLoader.yaml_implicit_resolvers = copy.deepcopy(yaml.SafeLoader.yaml_implicit_resolvers)
+for initial, resolvers in list(WorkflowLoader.yaml_implicit_resolvers.items()):
+    WorkflowLoader.yaml_implicit_resolvers[initial] = [
+        (tag, regex) for tag, regex in resolvers if tag != "tag:yaml.org,2002:bool"
+    ]
+WorkflowLoader.add_implicit_resolver(
+    "tag:yaml.org,2002:bool",
+    re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$"),
+    list("tTfF"),
+)
+
+
+def _construct_mapping(loader: WorkflowLoader, node: yaml.MappingNode, deep: bool = False) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise ValueError(f"duplicate YAML key: {key}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+WorkflowLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping)
+
+
+def load_workflow(path: Path) -> dict[str, Any]:
+    value = yaml.load(path.read_text(encoding="utf-8"), Loader=WorkflowLoader)
+    if not isinstance(value, dict):
+        raise ValueError("workflow root must be a mapping")
+    return value
+
+
+def _steps(workflow: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    result: list[tuple[str, dict[str, Any]]] = []
+    for job_name, job in workflow.get("jobs", {}).items():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps", []):
+            if isinstance(step, dict):
+                result.append((str(job_name), step))
+    return result
+
+
+def _run_text(job: dict[str, Any]) -> str:
+    return "\n".join(str(step.get("run", "")) for step in job.get("steps", []) if isinstance(step, dict))
+
+
+def _needs(job: dict[str, Any]) -> set[str]:
+    value = job.get("needs", [])
+    if isinstance(value, str):
+        return {value}
+    return {str(item) for item in value} if isinstance(value, list) else set()
+
+
+def validate_workflows(root: Path = WORKFLOW_ROOT) -> list[str]:
+    errors: list[str] = []
+    workflows: dict[str, dict[str, Any]] = {}
+    for path in sorted(root.glob("*.yml")):
+        try:
+            workflows[path.name] = load_workflow(path)
+        except Exception as exc:
+            errors.append(f"{path.name}: invalid YAML: {exc}")
+
+    for name, workflow in workflows.items():
+        for job_name, step in _steps(workflow):
+            uses = step.get("uses")
+            if not isinstance(uses, str) or uses.startswith("./"):
+                continue
+            action, separator, revision = uses.rpartition("@")
+            if not separator:
+                errors.append(f"{name}:{job_name}: action has no revision: {uses}")
+                continue
+            reviewed = REVIEWED_ACTIONS.get(action)
+            if reviewed and revision != reviewed:
+                errors.append(f"{name}:{job_name}: {action} must use reviewed SHA {reviewed}")
+            if name in FULLY_PINNED_WORKFLOWS and not FULL_SHA.fullmatch(revision):
+                errors.append(f"{name}:{job_name}: action must use a full commit SHA: {uses}")
+            if action == "actions/checkout" and step.get("with", {}).get("persist-credentials") is not False:
+                errors.append(f"{name}:{job_name}: checkout must set persist-credentials: false")
+
+    for name in IMAGE_WORKFLOWS:
+        workflow = workflows.get(name)
+        if workflow is None:
+            errors.append(f"missing image publication workflow: {name}")
+            continue
+        jobs = workflow.get("jobs", {})
+        preflight = jobs.get("preflight", {})
+        preflight_commands = _run_text(preflight)
+        if "distribution-release-check" not in preflight_commands:
+            errors.append(f"{name}: preflight must run strict distribution-release-check")
+        if "GITHUB_REF_TYPE" not in json.dumps(preflight) and "--validate-publish-ref" not in preflight_commands:
+            errors.append(f"{name}: preflight must validate the publication ref and version")
+        if "login-action" in "\n".join(str(step.get("uses", "")) for step in preflight.get("steps", [])):
+            errors.append(f"{name}: preflight must not log in to a registry")
+        if (
+            workflow.get("permissions", {}).get("packages") == "write"
+            or preflight.get("permissions", {}).get("packages") == "write"
+        ):
+            errors.append(f"{name}: preflight must not receive package-write permission")
+        if any(
+            isinstance(step, dict) and step.get("with", {}).get("push") is True
+            for step in preflight.get("steps", [])
+        ):
+            errors.append(f"{name}: preflight must not push an image")
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            push_steps = [
+                step for step in job.get("steps", [])
+                if isinstance(step, dict)
+                and str(step.get("uses", "")).startswith("docker/build-push-action@")
+                and step.get("with", {}).get("push") is True
+            ]
+            if not push_steps:
+                continue
+            if "preflight" not in _needs(job):
+                errors.append(f"{name}:{job_name}: publishing job must need preflight")
+            for step in push_steps:
+                settings = step.get("with", {})
+                if settings.get("sbom") is not True:
+                    errors.append(f"{name}:{job_name}: publishing build must enable sbom")
+                if settings.get("provenance") != "mode=max":
+                    errors.append(f"{name}:{job_name}: publishing build must use provenance: mode=max")
+        concurrency = workflow.get("concurrency", {})
+        if concurrency.get("cancel-in-progress") is not False:
+            errors.append(f"{name}: publication concurrency must not cancel an in-progress publish")
+
+    docker_text = (root / "docker-image.yml").read_text(encoding="utf-8") if (root / "docker-image.yml").exists() else ""
+    if "UNALTRAWEB_RUNTIME_IMAGE=ghcr.io/dosquartsdedocs/unaltraweb@${{ steps.runtime.outputs.digest }}" not in docker_text:
+        errors.append("docker-image.yml: MCP publication must use the exact runtime build digest")
+
+    codeql = workflows.get("codeql.yml", {})
+    codeql_on = codeql.get("on", {})
+    for event in ["push", "pull_request", "schedule"]:
+        if event not in codeql_on:
+            errors.append(f"codeql.yml: missing automatic {event} trigger")
+    codeql_text = json.dumps(codeql)
+    for language in ["javascript-typescript", "python", "ruby"]:
+        if language not in codeql_text:
+            errors.append(f"codeql.yml: missing {language} analysis")
+
+    ci = workflows.get("ci.yml", {})
+    ci_on = ci.get("on", {})
+    for event in ["push", "pull_request"]:
+        if event not in ci_on:
+            errors.append(f"ci.yml: missing automatic {event} trigger")
+    ci_text = json.dumps(ci)
+    for marker in [
+        "compileall", "unittest discover", "git diff --check", "distribution-check",
+        "wheel-check", "gem-check", "mcp-smoke-prebuilt", "docs-build",
+    ]:
+        if marker not in ci_text:
+            errors.append(f"ci.yml: missing required check {marker}")
+
+    package = workflows.get("package-prepare.yml", {})
+    package_text = json.dumps(package)
+    for marker in ["distribution-release-check", "wheel-check", "gem-check", "sha256sum", "actions/upload-artifact@"]:
+        if marker not in package_text:
+            errors.append(f"package-prepare.yml: missing release preparation step {marker}")
+    for forbidden in ["gem push", "twine upload", "gh release create", "docker push"]:
+        if forbidden in package_text:
+            errors.append(f"package-prepare.yml: forbidden publication command {forbidden}")
+    if "${{ github.sha }}" not in package_text or '"overwrite": false' not in package_text:
+        errors.append("package-prepare.yml: artifact must be SHA-named and immutable")
+    if package.get("permissions", {}).get("contents") != "read" or len(package.get("permissions", {})) != 1:
+        errors.append("package-prepare.yml: candidate preparation must have read-only repository permissions")
+    return errors
+
+
+def main() -> int:
+    errors = validate_workflows()
+    print(json.dumps({"ok": not errors, "errors": errors}, indent=2, sort_keys=True))
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/web_captures/render.py
+++ b/scripts/web_captures/render.py
@@ -32,7 +32,7 @@ except ImportError as exc:  # pragma: no cover - supplied by project tooling
 
 LOCK_PATH = Path(".unaltraweb/web-captures.lock.json")
 SOURCE_SUFFIXES = (".capture.yml", ".capture.yaml")
-DEFAULT_IMAGE = "ghcr.io/dosquartsdedocs/unaltraweb-web-capture:main"
+DEFAULT_IMAGE = "ghcr.io/dosquartsdedocs/unaltraweb-web-capture:0.3.0"
 DEFAULT_VIEWPORT = {"width": 1440, "height": 900, "device_scale_factor": 1}
 CAPTURE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,79}$")
 SAFE_SOURCE_RE = re.compile(r"^[A-Za-z0-9_./-]+\.capture\.ya?ml$")
@@ -585,20 +585,9 @@ def build_image(image: str) -> None:
     available = inspect_image(image)["available"] == "true"
     if available:
         return
-    if image != DEFAULT_IMAGE:
-        completed = subprocess.run(["docker", "pull", image], check=False)
-        if completed.returncode != 0:
-            raise WebCaptureError(f"Could not pull web capture image: {image}")
-        return
-    root = factory_root()
-    command = ["docker", "build"]
-    network = os.environ.get("WEB_CAPTURE_DOCKER_BUILD_NETWORK", "").strip()
-    if network:
-        command.extend(["--network", network])
-    command.extend(["-f", str(root / "scripts/web_captures/Dockerfile"), "-t", image, str(root)])
-    completed = subprocess.run(command, check=False)
+    completed = subprocess.run(["docker", "pull", image], check=False)
     if completed.returncode != 0:
-        raise WebCaptureError(f"Could not build web capture image: {image}")
+        raise WebCaptureError(f"Could not pull web capture image: {image}")
 
 
 def png_dimensions(path: Path) -> tuple[int, int]:
@@ -723,13 +712,38 @@ def run_worker(project: Path, image: str, config_path: Path) -> None:
     network = os.environ.get("WEB_CAPTURE_DOCKER_NETWORK", "").strip()
     if not internal_network(network):
         raise WebCaptureError("Browser capture requires a named isolated Docker network.")
+    worker_values = {
+        "role": os.environ.get("UNALTRAWEB_WORKER_ROLE", "").strip(),
+        "project": os.environ.get("UNALTRAWEB_WORKER_PROJECT", "").strip(),
+        "token": os.environ.get("UNALTRAWEB_WORKER_TOKEN", "").strip(),
+    }
+    worker_args: list[str] = []
+    cidfile: Path | None = None
+    if any(worker_values.values()):
+        if worker_values["role"] != "web-capture" or not re.fullmatch(r"[0-9a-f]{16}", worker_values["project"]) or not re.fullmatch(r"[0-9a-f]{16}", worker_values["token"]):
+            raise WebCaptureError("Web capture worker identity is incomplete or invalid.")
+        runtime = project / "tmp/.unaltraweb/web-captures"
+        runtime.mkdir(parents=True, exist_ok=True)
+        cidfile = runtime / f"worker-{worker_values['token']}.cid"
+        cidfile.unlink(missing_ok=True)
+        worker_args = [
+            "--cidfile", str(cidfile),
+            "--label", "io.context.mcp-factory=unaltraweb",
+            "--label", f"io.context.mcp-role={worker_values['role']}",
+            "--label", f"io.context.mcp-project={worker_values['project']}",
+            "--label", f"io.context.mcp-worker-token={worker_values['token']}",
+        ]
     command = [
-        "docker", "run", "--rm", "--user", f"{os.getuid()}:{os.getgid()}", "--network", network, "--ipc=host",
+        "docker", "run", "--rm", *worker_args, "--user", f"{os.getuid()}:{os.getgid()}", "--network", network, "--ipc=host",
         "--read-only", "--cap-drop", "ALL", "--security-opt", "no-new-privileges", "--pids-limit", "256", "--cpus", "2", "--memory", "2g",
         "--tmpfs", "/tmp:rw,noexec,nosuid,size=512m", "-e", "HOME=/tmp", "-v", f"{project}:/project:rw", "-w", "/project", image,
         "/project/" + relative(project, config_path),
     ]
-    completed = subprocess.run(command, check=False)
+    try:
+        completed = subprocess.run(command, check=False)
+    finally:
+        if cidfile is not None:
+            cidfile.unlink(missing_ok=True)
     if completed.returncode != 0:
         raise WebCaptureError(f"Browser capture failed with exit code {completed.returncode}.")
 

--- a/src/unaltraweb_mcp/__init__.py
+++ b/src/unaltraweb_mcp/__init__.py
@@ -1,1 +1,4 @@
-__version__ = "0.3.0"
+from .distribution import distribution_version
+
+
+__version__ = distribution_version()

--- a/src/unaltraweb_mcp/cli.py
+++ b/src/unaltraweb_mcp/cli.py
@@ -6,23 +6,101 @@ import sys
 from pathlib import Path
 
 from . import __version__
+from .distribution import distribution_doctor
 from . import site_tools as tools
+
+
+PACKAGE_ONLY_COMMANDS = {"doctor", "new-web", "version"}
+FACTORY_REQUIRED_COMMANDS = {"factory-dir"}
+FACTORY_REQUIRED_MCP_COMMANDS = {
+    "serve",
+    "site-check",
+    "manual-computation-status",
+    "manual-computation-check",
+    "manual-computation-render",
+    "manual-computation-render-figures",
+    "web-capture-status",
+    "web-capture-check",
+    "web-capture-render",
+    "manual-pdf-status",
+    "manual-pdf-build",
+    "manual-pdf-publish",
+    "bibliometrics-check",
+    "bibliometrics-fetch-scimago",
+    "bibliometrics-update",
+    "build-site",
+    "prompts",
+}
+PACKAGE_ONLY_MCP_COMMANDS = {
+    "bibliography-add-entry",
+    "bibliography-inventory",
+    "build-health",
+    "content-approval-inventory",
+    "content-freshness-check",
+    "content-inventory",
+    "detect-site",
+    "html-audit",
+    "http-check",
+    "initialize-site",
+    "language-policy",
+    "list-tools",
+    "manual-authoring-capabilities",
+    "manual-editorial-quality-check",
+    "manual-source-quality-check",
+    "new-web",
+    "preview-start",
+    "preview-status",
+    "preview-stop",
+    "profile-check",
+    "profile-prune",
+    "profile-prune-plan",
+    "scaffold-sync",
+    "site-context",
+    "site-doctor",
+    "site-source-delete",
+    "site-source-read",
+    "site-source-write",
+    "starter-templates",
+    "translation-plan",
+}
+ALL_MCP_COMMANDS = FACTORY_REQUIRED_MCP_COMMANDS | PACKAGE_ONLY_MCP_COMMANDS
 
 
 def source_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def factory_dir() -> Path:
+def find_factory_dir() -> Path | None:
     candidates = []
     configured = os.environ.get("UNALTRAWEB_FACTORY_DIR", "").strip()
     if configured:
         candidates.append(Path(configured))
+    candidates.append(Path.cwd())
     candidates.append(source_root())
     for candidate in candidates:
-        if (candidate / "mcp-factory.yml").is_file():
-            return candidate.expanduser().resolve()
-    raise SystemExit("unaltraweb factory assets not found; set UNALTRAWEB_FACTORY_DIR")
+        resolved = candidate.expanduser().resolve()
+        manifest_path = resolved / "mcp-factory.yml"
+        if not manifest_path.is_file():
+            continue
+        try:
+            manifest = tools.load_yaml_file(manifest_path)
+        except Exception:
+            # YAML parser failures do not share one exception base across optional loaders.
+            continue
+        if manifest.get("name") == "unaltraweb":
+            return resolved
+    return None
+
+
+def factory_dir(command: str = "") -> Path:
+    factory = find_factory_dir()
+    if factory is not None:
+        return factory
+    label = f"MCP command '{command}'" if command else "This command"
+    raise SystemExit(
+        f"{label} requires the unaltraweb factory checkout. The modular wheel provides version, doctor, new-web, "
+        "and package-only inspection without factory assets; set UNALTRAWEB_FACTORY_DIR to a checkout containing mcp-factory.yml."
+    )
 
 
 def project_dir(raw: str | None) -> Path:
@@ -40,14 +118,14 @@ def cmd_version(_: argparse.Namespace) -> int:
 
 
 def cmd_factory_dir(_: argparse.Namespace) -> int:
-    print(factory_dir())
+    print(factory_dir("factory-dir"))
     return 0
 
 
 def cmd_new_web(args: argparse.Namespace) -> int:
     return print_json(
         tools.new_web(
-            Path(args.project),
+            Path(args.project or os.getcwd()),
             site_profile_value=args.site_profile,
             title=args.title,
             baseurl=args.baseurl,
@@ -59,10 +137,19 @@ def cmd_new_web(args: argparse.Namespace) -> int:
     )
 
 
+def cmd_doctor(args: argparse.Namespace) -> int:
+    raw_project = args.doctor_project if args.doctor_project is not None else args.project
+    project = project_dir(raw_project) if raw_project is not None else None
+    return print_json(
+        distribution_doctor(project=project, factory=find_factory_dir(), check_docker=args.docker),
+        enforce_ok=True,
+    )
+
+
 def cmd_mcp(args: argparse.Namespace) -> int:
     project = project_dir(args.project)
-    factory = factory_dir()
     command = args.mcp_command
+    factory = factory_dir(command) if command in FACTORY_REQUIRED_MCP_COMMANDS else find_factory_dir()
     if command == "serve":
         from .mcp_server import run_server
 
@@ -94,8 +181,38 @@ def cmd_mcp(args: argparse.Namespace) -> int:
         return cmd_new_web(args)
     if command == "site-context":
         return print_json(tools.site_context(project, factory))
+    if command == "site-doctor":
+        return print_json(tools.site_doctor(project, factory), enforce_ok=True)
     if command == "site-check":
         return print_json(tools.site_check(project, factory), enforce_ok=True)
+    if command == "site-source-read":
+        return print_json(tools.site_source_read(project, args.path))
+    if command == "site-source-write":
+        return print_json(
+            tools.site_source_write(
+                project,
+                args.path,
+                args.content,
+                expected_sha256=args.expected_sha256,
+                create_only=args.create_only,
+                dry_run=not args.apply,
+            )
+        )
+    if command == "site-source-delete":
+        return print_json(
+            tools.site_source_delete(
+                project,
+                args.path,
+                expected_sha256=args.expected_sha256,
+                dry_run=not args.apply,
+                confirm_delete=args.confirm_delete,
+            )
+        )
+    if command == "scaffold-sync":
+        return print_json(
+            tools.scaffold_sync(project, dry_run=not args.apply, confirm_sync=args.confirm_sync),
+            enforce_ok=True,
+        )
     if command == "profile-check":
         return print_json(tools.profile_check(project), enforce_ok=True)
     if command == "manual-source-quality-check":
@@ -159,9 +276,11 @@ def cmd_mcp(args: argparse.Namespace) -> int:
             )
         )
     if command == "build-site":
-        return print_json(tools.build_site(project, factory, site_profile=args.site_profile))
+        return print_json(tools.build_site(project, factory, site_profile=args.site_profile), enforce_ok=True)
     if command == "build-health":
         return print_json(tools.build_health(project))
+    if command == "html-audit":
+        return print_json(tools.html_audit(project), enforce_ok=True)
     if command == "preview-start":
         return print_json(tools.preview_start(project, port=args.port, site_profile=args.site_profile, timeout_seconds=args.timeout_seconds))
     if command == "preview-status":
@@ -169,7 +288,7 @@ def cmd_mcp(args: argparse.Namespace) -> int:
     if command == "preview-stop":
         return print_json(tools.preview_stop(project))
     if command == "http-check":
-        return print_json(tools.http_check(args.base_url, paths=args.paths, timeout_seconds=args.timeout_seconds))
+        return print_json(tools.http_check(project, paths=args.paths, timeout_seconds=args.timeout_seconds), enforce_ok=True)
     if command == "prompts":
         return print_json(tools.prompt_inventory(factory))
     raise SystemExit(f"unsupported mcp command: {command}")
@@ -177,11 +296,16 @@ def cmd_mcp(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="unaltraweb-mcp")
-    parser.add_argument("--project", default=".", help="Consumer website workspace. Defaults to current directory.")
+    parser.add_argument("--project", default=None, help="Consumer website workspace. Defaults to current directory for project commands.")
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("version").set_defaults(func=cmd_version)
     sub.add_parser("factory-dir").set_defaults(func=cmd_factory_dir)
+
+    doctor = sub.add_parser("doctor", help="Inspect the modular distribution contract without network access")
+    doctor.add_argument("--project", dest="doctor_project", default=None, help="Optional consumer project to inspect.")
+    doctor.add_argument("--docker", action="store_true", help="Inspect selected local Docker images without pulling.")
+    doctor.set_defaults(func=cmd_doctor)
 
     new_web = sub.add_parser("new-web", help="Create a website from a package-owned profile scaffold")
     _add_new_web_arguments(new_web)
@@ -189,8 +313,28 @@ def build_parser() -> argparse.ArgumentParser:
 
     mcp = sub.add_parser("mcp", help="MCP server and JSON helper commands")
     mcp_sub = mcp.add_subparsers(dest="mcp_command", required=True)
-    for name in ["serve", "list-tools", "starter-templates", "detect-site", "site-context", "site-check", "profile-check", "manual-source-quality-check", "manual-editorial-quality-check", "manual-authoring-capabilities", "content-inventory", "language-policy", "bibliography-inventory", "bibliometrics-check", "build-health", "preview-stop", "prompts"]:
+    for name in ["serve", "list-tools", "starter-templates", "detect-site", "site-context", "site-doctor", "site-check", "profile-check", "manual-source-quality-check", "manual-editorial-quality-check", "manual-authoring-capabilities", "content-inventory", "language-policy", "bibliography-inventory", "bibliometrics-check", "build-health", "html-audit", "preview-stop", "prompts"]:
         mcp_sub.add_parser(name)
+
+    source_read = mcp_sub.add_parser("site-source-read")
+    source_read.add_argument("--path", required=True)
+
+    source_write = mcp_sub.add_parser("site-source-write")
+    source_write.add_argument("--path", required=True)
+    source_write.add_argument("--content", required=True)
+    source_write.add_argument("--expected-sha256", default="")
+    source_write.add_argument("--create-only", action="store_true")
+    source_write.add_argument("--apply", action="store_true")
+
+    source_delete = mcp_sub.add_parser("site-source-delete")
+    source_delete.add_argument("--path", required=True)
+    source_delete.add_argument("--expected-sha256", required=True)
+    source_delete.add_argument("--apply", action="store_true")
+    source_delete.add_argument("--confirm-delete", action="store_true")
+
+    scaffold_sync = mcp_sub.add_parser("scaffold-sync")
+    scaffold_sync.add_argument("--apply", action="store_true")
+    scaffold_sync.add_argument("--confirm-sync", action="store_true")
 
     mcp_new_web = mcp_sub.add_parser("new-web")
     _add_new_web_arguments(mcp_new_web)
@@ -281,9 +425,8 @@ def build_parser() -> argparse.ArgumentParser:
     preview_status.add_argument("--include-logs", action="store_true")
 
     http = mcp_sub.add_parser("http-check")
-    http.add_argument("--base-url", default="http://127.0.0.1:4000")
-    http.add_argument("--paths", nargs="*", default=["/"])
-    http.add_argument("--timeout-seconds", type=float, default=5.0)
+    http.add_argument("--paths", nargs="*", default=None)
+    http.add_argument("--timeout-seconds", type=float, default=3.0)
 
     mcp.set_defaults(func=cmd_mcp)
     return parser

--- a/src/unaltraweb_mcp/component-contract.json
+++ b/src/unaltraweb_mcp/component-contract.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "component-contract.schema.json",
+  "schema_version": 1,
+  "release": {
+    "version": "0.3.0",
+    "tag": "v0.3.0"
+  },
+  "receipt_contract": {
+    "schema_version": 1,
+    "path_template": ".unaltraweb/receipts/{provider}.json",
+    "hash_algorithm": "sha256",
+    "input_inventory": "exact",
+    "vegavisuals_dependencies": ["manifest.inputs", "visualizations[].inputs", "spec.data.url"],
+    "diavisuals_dependencies": [],
+    "local_dependency_policy": "project-relative-static-only",
+    "unverifiable_dependency_policy": "error"
+  },
+  "wheel_contract": {
+    "package": "unaltraweb-mcp",
+    "role": "Modular control, scaffolding, and offline inspection plane for unaltraweb sites.",
+    "package_only_commands": ["doctor", "new-web", "version"],
+    "factory_required_commands": ["factory-dir"],
+    "package_only_mcp": ["bibliography-add-entry", "bibliography-inventory", "build-health", "content-approval-inventory", "content-freshness-check", "content-inventory", "detect-site", "html-audit", "http-check", "initialize-site", "language-policy", "list-tools", "manual-authoring-capabilities", "manual-editorial-quality-check", "manual-source-quality-check", "new-web", "preview-start", "preview-status", "preview-stop", "profile-check", "profile-prune", "profile-prune-plan", "scaffold-sync", "site-context", "site-doctor", "site-source-delete", "site-source-read", "site-source-write", "starter-templates", "translation-plan"],
+    "factory_required_mcp": ["bibliometrics-check", "bibliometrics-fetch-scimago", "bibliometrics-update", "build-site", "manual-computation-check", "manual-computation-render", "manual-computation-render-figures", "manual-computation-status", "manual-pdf-build", "manual-pdf-publish", "manual-pdf-status", "prompts", "serve", "site-check", "web-capture-check", "web-capture-render", "web-capture-status"],
+    "not_bundled": ["gem", "runtime", "mcp", "compute_python", "compute_r", "web_capture", "manual_pdf", "diavisuals", "vegavisuals"]
+  },
+  "components": {
+    "gem": {
+      "kind": "gem",
+      "name": "unaltraweb",
+      "version": "0.3.0",
+      "release": "v0.3.0",
+      "release_status": "released",
+      "reference": "unaltraweb (= 0.3.0)",
+      "repository": "https://github.com/dosquartsdedocs/unaltraweb",
+      "included_in_wheel": false,
+      "features": ["jekyll-core", "site-build"]
+    },
+    "wheel": {
+      "kind": "python-wheel",
+      "name": "unaltraweb-mcp",
+      "version": "0.3.0",
+      "release": "v0.3.0",
+      "release_status": "released",
+      "reference": "unaltraweb-mcp==0.3.0",
+      "repository": "https://github.com/dosquartsdedocs/unaltraweb",
+      "included_in_wheel": true,
+      "features": ["doctor", "new-web", "offline-inspection", "mcp-control-plane"]
+    },
+    "runtime": {
+      "kind": "container",
+      "name": "unaltraweb runtime",
+      "version": "0.3.0",
+      "release": "v0.3.0",
+      "release_status": "released",
+      "reference": "ghcr.io/dosquartsdedocs/unaltraweb:0.3.0",
+      "repository": "https://github.com/dosquartsdedocs/unaltraweb",
+      "included_in_wheel": false,
+      "features": ["jekyll-runtime"]
+    },
+    "mcp": {
+      "kind": "container",
+      "name": "unaltraweb MCP runtime",
+      "version": "0.3.0",
+      "release": "v0.3.0",
+      "release_status": "released",
+      "reference": "ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0",
+      "repository": "https://github.com/dosquartsdedocs/unaltraweb",
+      "included_in_wheel": false,
+      "features": ["mcp", "consumer-build", "preview"]
+    },
+    "compute_python": {
+      "kind": "container",
+      "name": "unaltraweb Python computation worker",
+      "version": "0.3.0",
+      "release": "v0.3.0",
+      "release_status": "released",
+      "reference": "ghcr.io/dosquartsdedocs/unaltraweb-compute-python:0.3.0",
+      "repository": "https://github.com/dosquartsdedocs/unaltraweb",
+      "included_in_wheel": false,
+      "features": ["manual-computations", "python"]
+    },
+    "compute_r": {
+      "kind": "container",
+      "name": "unaltraweb R computation worker",
+      "version": "0.3.0",
+      "release": "v0.3.0",
+      "release_status": "released",
+      "reference": "ghcr.io/dosquartsdedocs/unaltraweb-compute-r:0.3.0",
+      "repository": "https://github.com/dosquartsdedocs/unaltraweb",
+      "included_in_wheel": false,
+      "features": ["manual-computations", "r"]
+    },
+    "web_capture": {
+      "kind": "container",
+      "name": "unaltraweb web capture worker",
+      "version": "0.3.0",
+      "release": "v0.3.0",
+      "release_status": "released",
+      "reference": "ghcr.io/dosquartsdedocs/unaltraweb-web-capture:0.3.0",
+      "repository": "https://github.com/dosquartsdedocs/unaltraweb",
+      "included_in_wheel": false,
+      "features": ["web-captures"]
+    },
+    "manual_pdf": {
+      "kind": "container",
+      "name": "unaltraweb manual PDF worker",
+      "version": "0.3.0",
+      "release": "v0.3.0",
+      "release_status": "released",
+      "reference": "ghcr.io/dosquartsdedocs/unaltraweb-manual-pdf:0.3.0",
+      "repository": "https://github.com/dosquartsdedocs/unaltraweb",
+      "included_in_wheel": false,
+      "features": ["manual-pdf"]
+    },
+    "diavisuals": {
+      "kind": "companion",
+      "name": "diavisuals",
+      "version": "0.3.1",
+      "release": "v0.3.1",
+      "release_status": "pending",
+      "reference": "https://github.com/dosquartsdedocs/diavisuals.git@v0.3.1",
+      "repository": "https://github.com/dosquartsdedocs/diavisuals",
+      "included_in_wheel": false,
+      "features": ["mermaid", "plantuml"]
+    },
+    "vegavisuals": {
+      "kind": "companion",
+      "name": "vegavisuals",
+      "version": "0.3.1",
+      "release": "v0.3.1",
+      "release_status": "pending",
+      "reference": "https://github.com/dosquartsdedocs/vegavisuals.git@v0.3.1",
+      "repository": "https://github.com/dosquartsdedocs/vegavisuals",
+      "included_in_wheel": false,
+      "features": ["vega", "vega-lite"]
+    }
+  }
+}

--- a/src/unaltraweb_mcp/component-contract.schema.json
+++ b/src/unaltraweb_mcp/component-contract.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dosquartsdedocs.github.io/unaltraweb/schemas/component-contract-v1.schema.json",
+  "title": "unaltraweb component contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "release", "receipt_contract", "wheel_contract", "components"],
+  "properties": {
+    "$schema": {"type": "string"},
+    "schema_version": {"const": 1},
+    "release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "tag"],
+      "properties": {
+        "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+        "tag": {"type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"}
+      }
+    },
+    "receipt_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "path_template", "hash_algorithm", "input_inventory", "vegavisuals_dependencies", "diavisuals_dependencies", "local_dependency_policy", "unverifiable_dependency_policy"],
+      "properties": {
+        "schema_version": {"const": 1},
+        "path_template": {"const": ".unaltraweb/receipts/{provider}.json"},
+        "hash_algorithm": {"const": "sha256"},
+        "input_inventory": {"const": "exact"},
+        "vegavisuals_dependencies": {"const": ["manifest.inputs", "visualizations[].inputs", "spec.data.url"]},
+        "diavisuals_dependencies": {"const": []},
+        "local_dependency_policy": {"const": "project-relative-static-only"},
+        "unverifiable_dependency_policy": {"const": "error"}
+      }
+    },
+    "wheel_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["package", "role", "package_only_commands", "factory_required_commands", "package_only_mcp", "factory_required_mcp", "not_bundled"],
+      "properties": {
+        "package": {"const": "unaltraweb-mcp"},
+        "role": {"type": "string"},
+        "package_only_commands": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "factory_required_commands": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "package_only_mcp": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "factory_required_mcp": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "not_bundled": {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+      }
+    },
+    "components": {
+      "type": "object",
+      "required": ["gem", "wheel", "runtime", "mcp", "compute_python", "compute_r", "web_capture", "manual_pdf", "diavisuals", "vegavisuals"],
+      "additionalProperties": {"$ref": "#/$defs/component"}
+    }
+  },
+  "$defs": {
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "name", "version", "release", "release_status", "reference", "repository", "included_in_wheel", "features"],
+      "properties": {
+        "kind": {"enum": ["gem", "python-wheel", "container", "companion"]},
+        "name": {"type": "string"},
+        "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+        "release": {"type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"},
+        "release_status": {"enum": ["released", "pending", "unavailable"]},
+        "reference": {"type": "string"},
+        "repository": {"type": "string", "pattern": "^https://"},
+        "included_in_wheel": {"type": "boolean"},
+        "features": {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+      }
+    }
+  }
+}

--- a/src/unaltraweb_mcp/distribution.py
+++ b/src/unaltraweb_mcp/distribution.py
@@ -1,0 +1,629 @@
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from .processes import run_process
+
+
+CONTRACT_NAME = "component-contract.json"
+CONTRACT_SCHEMA_NAME = "component-contract.schema.json"
+DOCTOR_SCHEMA_VERSION = 1
+MUTABLE_TAGS = {"edge", "latest", "main", "master", "nightly", "stable"}
+
+
+def _strict_json(path: Path) -> Any:
+    def reject(value: str) -> None:
+        raise ValueError(f"non-finite JSON number is not allowed: {value}")
+
+    return json.loads(path.read_text(encoding="utf-8"), parse_constant=reject)
+
+
+def _schema_type_matches(value: Any, expected: str) -> bool:
+    return {
+        "object": isinstance(value, dict),
+        "array": isinstance(value, list),
+        "string": isinstance(value, str),
+        "boolean": isinstance(value, bool),
+        "integer": isinstance(value, int) and not isinstance(value, bool),
+        "number": isinstance(value, (int, float)) and not isinstance(value, bool),
+        "null": value is None,
+    }.get(expected, False)
+
+
+def _validate_schema_value(value: Any, rule: dict[str, Any], root: dict[str, Any], path: str) -> None:
+    if "$ref" in rule:
+        reference = str(rule["$ref"])
+        if not reference.startswith("#/"):
+            raise RuntimeError(f"Unsupported external schema reference at {path}: {reference}")
+        selected: Any = root
+        for part in reference[2:].split("/"):
+            selected = selected[part.replace("~1", "/").replace("~0", "~")]
+        _validate_schema_value(value, selected, root, path)
+        return
+    expected_type = rule.get("type")
+    if expected_type and not _schema_type_matches(value, str(expected_type)):
+        raise RuntimeError(f"Component contract {path} must have type {expected_type}.")
+    if "const" in rule and value != rule["const"]:
+        raise RuntimeError(f"Component contract {path} must equal {rule['const']!r}.")
+    if "enum" in rule and value not in rule["enum"]:
+        raise RuntimeError(f"Component contract {path} is not one of {rule['enum']!r}.")
+    if "pattern" in rule and isinstance(value, str) and re.search(str(rule["pattern"]), value) is None:
+        raise RuntimeError(f"Component contract {path} does not match {rule['pattern']!r}.")
+    if isinstance(value, dict):
+        properties = rule.get("properties") if isinstance(rule.get("properties"), dict) else {}
+        required = rule.get("required") if isinstance(rule.get("required"), list) else []
+        missing = [key for key in required if key not in value]
+        if missing:
+            raise RuntimeError(f"Component contract {path} is missing required keys: {missing}.")
+        additional = rule.get("additionalProperties", True)
+        for key, item in value.items():
+            item_path = f"{path}.{key}"
+            if key in properties:
+                _validate_schema_value(item, properties[key], root, item_path)
+            elif additional is False:
+                raise RuntimeError(f"Component contract {item_path} is not allowed by the schema.")
+            elif isinstance(additional, dict):
+                _validate_schema_value(item, additional, root, item_path)
+    if isinstance(value, list):
+        if rule.get("uniqueItems") and len({json.dumps(item, sort_keys=True) for item in value}) != len(value):
+            raise RuntimeError(f"Component contract {path} must contain unique items.")
+        items = rule.get("items")
+        if isinstance(items, dict):
+            for index, item in enumerate(value):
+                _validate_schema_value(item, items, root, f"{path}[{index}]")
+
+
+def validate_component_contract(value: dict[str, Any], schema: dict[str, Any]) -> None:
+    _validate_schema_value(value, schema, schema, "$")
+
+
+def component_contract_semantic_errors(value: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    release = value["release"]
+    release_version = str(release["version"])
+    if release["tag"] != f"v{release_version}":
+        errors.append("release tag must equal v plus the release version")
+    for component_id, selected in value["components"].items():
+        version = str(selected["version"])
+        component_release = str(selected["release"])
+        reference = str(selected["reference"])
+        repository = str(selected["repository"])
+        if component_release != f"v{version}":
+            errors.append(f"{component_id} release must equal v plus its version")
+        kind = selected["kind"]
+        if selected["release_status"] != "released" and kind != "companion":
+            errors.append(f"{component_id} may be pending or unavailable only when it is an external companion")
+        if kind == "gem" and reference != f"{selected['name']} (= {version})":
+            errors.append(f"{component_id} gem reference does not match its version")
+        elif kind == "python-wheel" and reference != f"{selected['name']}=={version}":
+            errors.append(f"{component_id} wheel reference does not match its version")
+        elif kind == "container" and "@sha256:" not in reference and not reference.endswith(f":{version}"):
+            errors.append(f"{component_id} container reference does not match its version")
+        elif kind == "companion" and reference != f"{repository}.git@{component_release}":
+            errors.append(f"{component_id} companion reference does not match its repository and release")
+    included = {name for name, item in value["components"].items() if item["included_in_wheel"]}
+    if included != {"wheel"}:
+        errors.append("only the wheel component may be included in the wheel")
+    expected_not_bundled = set(value["components"]) - {"wheel"}
+    if set(value["wheel_contract"]["not_bundled"]) != expected_not_bundled:
+        errors.append("wheel_contract.not_bundled must list every external component exactly")
+    return errors
+
+
+@lru_cache(maxsize=1)
+def _contract() -> dict[str, Any]:
+    path = Path(__file__).resolve().with_name(CONTRACT_NAME)
+    schema_path = path.with_name(CONTRACT_SCHEMA_NAME)
+    try:
+        value = _strict_json(path)
+        schema = _strict_json(schema_path)
+        if not isinstance(value, dict) or not isinstance(schema, dict):
+            raise RuntimeError("Component contract and schema roots must be JSON objects.")
+        validate_component_contract(value, schema)
+        semantic_errors = component_contract_semantic_errors(value)
+        if semantic_errors:
+            raise RuntimeError("; ".join(semantic_errors))
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError, KeyError, RuntimeError) as exc:
+        raise RuntimeError(f"Unsupported or invalid package component contract: {path}: {exc}") from exc
+    return value
+
+
+def distribution_contract() -> dict[str, Any]:
+    """Return an isolated copy of the package-owned component BOM."""
+    return json.loads(json.dumps(_contract()))
+
+
+def distribution_version() -> str:
+    return str(_contract()["release"]["version"])
+
+
+def component(component_id: str) -> dict[str, Any]:
+    try:
+        value = _contract()["components"][component_id]
+    except KeyError as exc:
+        raise KeyError(f"Unknown unaltraweb component: {component_id}") from exc
+    return dict(value)
+
+
+def component_reference(component_id: str) -> str:
+    return str(component(component_id)["reference"])
+
+
+def is_mutable_reference(reference: str) -> bool:
+    value = reference.strip().lower()
+    if not value:
+        return True
+    if re.search(r"@sha256:[0-9a-f]{64}$", value):
+        return False
+    if value.startswith("http") and ".git@" in value:
+        selected = value.rsplit("@", 1)[-1]
+        return selected in MUTABLE_TAGS or selected.startswith("refs/heads/")
+    if "@" in value:
+        return True
+    image_name = value.rsplit("/", 1)[-1]
+    if ":" not in image_name:
+        return True
+    tag = image_name.rsplit(":", 1)[-1]
+    return not tag or tag in MUTABLE_TAGS
+
+
+def _finding(
+    code: str,
+    severity: str,
+    expected: Any,
+    actual: Any,
+    remediation: str,
+    *,
+    component_id: str = "",
+) -> dict[str, Any]:
+    finding = {
+        "code": code,
+        "severity": severity,
+        "expected": expected,
+        "actual": actual,
+        "remediation": remediation,
+    }
+    if component_id:
+        finding["component"] = component_id
+    return finding
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    from .site_tools import load_yaml_file
+
+    return load_yaml_file(path)
+
+
+def _make_value(path: Path, variable: str) -> str:
+    if not path.is_file():
+        return ""
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    match = re.search(rf"(?m)^{re.escape(variable)}\s*\?[:+]?=\s*([^\s#]+)", text)
+    return match.group(1).strip('"\'') if match else ""
+
+
+def _factory_findings(factory: Path) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    contract = _contract()
+    expected_version = distribution_version()
+    manifest = _load_yaml(factory / "mcp-factory.yml")
+    actual_version = str(manifest.get("version") or "")
+    findings.append(
+        _finding(
+            "UW-DIST-FACTORY-VERSION",
+            "info" if actual_version == expected_version else "error",
+            expected_version,
+            actual_version or "unreadable",
+            "No action required." if actual_version == expected_version else "Use a factory checkout from the wheel's selected release.",
+        )
+    )
+
+    runtime = manifest.get("runtime") if isinstance(manifest.get("runtime"), dict) else {}
+    actual_mcp = str(runtime.get("image") or "")
+    expected_mcp = component_reference("mcp")
+    findings.append(
+        _finding(
+            "UW-DIST-FACTORY-MCP-PIN",
+            "info" if actual_mcp == expected_mcp else "error",
+            expected_mcp,
+            actual_mcp or "missing",
+            "No action required." if actual_mcp == expected_mcp else "Align runtime.image with the package component contract.",
+            component_id="mcp",
+        )
+    )
+
+    dependencies = manifest.get("mcp_dependencies") if isinstance(manifest.get("mcp_dependencies"), list) else []
+    dependency_map = {str(item.get("name")): item for item in dependencies if isinstance(item, dict)}
+    receipt_tools = {"diavisuals": "project_check", "vegavisuals": "visualization_check"}
+    for component_id in ["diavisuals", "vegavisuals"]:
+        expected = contract["components"][component_id]
+        dependency = dependency_map.get(component_id, {})
+        actual = {
+            "version": str(dependency.get("version") or ""),
+            "release": str(dependency.get("release") or ""),
+            "release_status": str(dependency.get("release_status") or ""),
+            "remote": str(dependency.get("remote") or ""),
+        }
+        selected = {
+            "version": expected["version"],
+            "release": expected["release"],
+            "release_status": expected["release_status"],
+            "remote": expected["repository"] + ".git",
+        }
+        findings.append(
+            _finding(
+                "UW-DIST-COMPANION-PIN",
+                "info" if actual == selected else "error",
+                selected,
+                actual,
+                "No action required." if actual == selected else f"Pin {component_id} to the selected HTTPS release metadata.",
+                component_id=component_id,
+            )
+        )
+        declared_tools = dependency.get("required_tools") if isinstance(dependency.get("required_tools"), list) else []
+        receipt_tool = receipt_tools[component_id]
+        findings.append(
+            _finding(
+                "UW-DIST-COMPANION-RECEIPT-TOOL",
+                "info" if receipt_tool in declared_tools else "error",
+                receipt_tool,
+                declared_tools,
+                "No action required." if receipt_tool in declared_tools else f"Require {receipt_tool} from {component_id} before enforcing its provider receipt.",
+                component_id=component_id,
+            )
+        )
+
+    makefile = factory / "Makefile"
+    make_pins = {
+        "MCP_RUNTIME_IMAGE": "runtime",
+        "MCP_IMAGE": "mcp",
+        "WEB_CAPTURE_IMAGE": "web_capture",
+        "DOCKER_IMAGE": "runtime",
+        "MANUAL_PDF_IMAGE": "manual_pdf",
+    }
+    for variable, component_id in make_pins.items():
+        expected = component_reference(component_id)
+        actual = _make_value(makefile, variable)
+        findings.append(
+            _finding(
+                "UW-DIST-FACTORY-COMPONENT-PIN",
+                "info" if actual == expected else "error",
+                expected,
+                actual or f"{variable} missing",
+                "No action required." if actual == expected else f"Set {variable} to the selected component reference.",
+                component_id=component_id,
+            )
+        )
+    return findings
+
+
+def _nested(mapping: dict[str, Any], *keys: str) -> Any:
+    value: Any = mapping
+    for key in keys:
+        if not isinstance(value, dict):
+            return None
+        value = value.get(key)
+    return value
+
+
+def _project_image_references(config: dict[str, Any]) -> list[tuple[str, str]]:
+    references: list[tuple[str, str]] = []
+    engines = config.get("engines") if isinstance(config.get("engines"), dict) else {}
+    for engine in ["python", "r"]:
+        settings = engines.get(engine) if isinstance(engines.get(engine), dict) else {}
+        for key in ["image", "base_image"]:
+            value = str(settings.get(key) or "").strip()
+            if value:
+                references.append((f"{engine}.{key}", value))
+        environments = settings.get("environments") if isinstance(settings.get("environments"), dict) else {}
+        for name, value in environments.items():
+            if str(value).strip():
+                references.append((f"{engine}.environments.{name}", str(value).strip()))
+    return references
+
+
+def _has_files(project: Path, patterns: list[str], roots: list[str]) -> bool:
+    for root_name in roots:
+        root = project / root_name
+        if not root.is_dir():
+            continue
+        for pattern in patterns:
+            if next(root.rglob(pattern), None) is not None:
+                return True
+    return False
+
+
+def _project_findings(project: Path) -> tuple[list[dict[str, Any]], dict[str, Any], dict[str, str], list[str]]:
+    findings: list[dict[str, Any]] = []
+    images: dict[str, str] = {}
+    selected_components = ["wheel"]
+    if not project.exists() or not project.is_dir():
+        findings.append(_finding("UW-DIST-PROJECT", "error", "existing project directory", str(project), "Pass an existing consumer project directory."))
+        return findings, {"supplied": True, "path": str(project), "is_unaltraweb_site": False}, images, selected_components
+
+    from . import site_tools
+
+    detection = site_tools.detect_site(project)
+    config = site_tools.site_config(project)
+    is_site = bool(detection["is_unaltraweb_site"])
+    profile = site_tools.site_profile(config)
+    project_state: dict[str, Any] = {
+        "supplied": True,
+        "path": str(project),
+        "is_unaltraweb_site": is_site,
+        "profile": profile,
+    }
+    findings.append(
+        _finding(
+            "UW-DIST-PROJECT-CONFIG",
+            "info" if is_site else "warning",
+            "unaltraweb consumer markers in _config.yml and Gemfile",
+            "unaltraweb consumer site" if is_site else "no complete consumer markers",
+            "No action required." if is_site else "Pass an unaltraweb site or omit --project for distribution-only checks.",
+        )
+    )
+    if not is_site:
+        return findings, project_state, images, selected_components
+
+    selected_components.extend(["gem", "mcp"])
+    gem_version = component("gem")["version"]
+    gemfile = (project / "Gemfile").read_text(encoding="utf-8", errors="ignore") if (project / "Gemfile").is_file() else ""
+    exact_gem = bool(re.search(rf"(?m)^\s*gem\s+['\"]unaltraweb['\"]\s*,\s*['\"](?:=\s*)?{re.escape(gem_version)}['\"]", gemfile))
+    lock_text = (project / "Gemfile.lock").read_text(encoding="utf-8", errors="ignore") if (project / "Gemfile.lock").is_file() else ""
+    lock_match = re.search(r"(?m)^\s{2}unaltraweb \(= ([^)]+)\)\s*$", lock_text)
+    locked_gem = lock_match.group(1) if lock_match else ""
+    gem_ok = exact_gem and locked_gem == gem_version
+    findings.append(
+        _finding(
+            "UW-DIST-PROJECT-GEM-PIN",
+            "info" if gem_ok else "warning",
+            f"Gemfile and Gemfile.lock pin {gem_version}",
+            {"gemfile_exact": exact_gem, "lock_version": locked_gem or "missing"},
+            "No action required." if gem_ok else "Pin the gem to the selected release and refresh Gemfile.lock.",
+            component_id="gem",
+        )
+    )
+
+    makefile = project / "Makefile"
+    expected_mcp = component_reference("mcp")
+    actual_mcp = _make_value(makefile, "MCP_IMAGE")
+    mcp_severity = "info" if actual_mcp == expected_mcp else ("warning" if not actual_mcp else "error")
+    findings.append(
+        _finding(
+            "UW-DIST-PROJECT-MCP-PIN",
+            mcp_severity,
+            expected_mcp,
+            actual_mcp or "MCP_IMAGE not declared",
+            "No action required." if actual_mcp == expected_mcp else "Use the selected MCP image, or document an intentional immutable override.",
+            component_id="mcp",
+        )
+    )
+    images["mcp"] = actual_mcp or expected_mcp
+
+    runtime_image = _make_value(makefile, "DOCKER_IMAGE")
+    if runtime_image:
+        selected_components.append("runtime")
+        images["runtime"] = runtime_image
+
+    computations_path = project / ".unaltraweb/computations.yml"
+    computation_sources = _has_files(project, ["*.qmd", "*.Rmd", "*.rmd", "*.R", "*.r", "*.py", "*.ipynb"], ["_chapters", "assets"])
+    computation_enabled = computations_path.is_file() or computation_sources
+    capture_enabled = _has_files(project, ["*.capture.yml", "*.capture.yaml"], ["assets", "_chapters"])
+    pdf_enabled = _nested(config, "unaltraweb", "manual", "pdf", "enabled") is True
+    vega_enabled = (project / ".vegavisuals.yml").is_file()
+    diagram_enabled = _has_files(project, ["*.mmd", "*.mermaid", "*.puml", "*.plantuml", "*.uml"], ["assets", "_chapters", "_documentation"])
+    features = {
+        "manual_computations": computation_enabled,
+        "web_captures": capture_enabled,
+        "manual_pdf": pdf_enabled,
+        "vegavisuals": vega_enabled,
+        "diavisuals": diagram_enabled,
+    }
+    project_state["features"] = features
+
+    if computation_enabled:
+        computation_config = _load_yaml(computations_path)
+        configured_engines = computation_config.get("engines") if isinstance(computation_config.get("engines"), dict) else {}
+        engine_ids = [engine for engine in ["python", "r"] if engine in configured_engines]
+        if not engine_ids:
+            engine_ids = ["python", "r"]
+        for engine in engine_ids:
+            component_id = f"compute_{engine}"
+            selected_components.append(component_id)
+            settings = configured_engines.get(engine) if isinstance(configured_engines.get(engine), dict) else {}
+            images[component_id] = str(settings.get("image") or component_reference(component_id))
+        for location, reference in _project_image_references(computation_config):
+            if is_mutable_reference(reference):
+                findings.append(
+                    _finding(
+                        "UW-DIST-PROJECT-MUTABLE-PIN",
+                        "warning",
+                        "version tag or digest",
+                        f"{location}={reference}",
+                        "Replace mutable worker tags with a release tag or digest.",
+                    )
+                )
+
+    if capture_enabled:
+        selected_components.append("web_capture")
+        images["web_capture"] = _make_value(makefile, "WEB_CAPTURE_IMAGE") or component_reference("web_capture")
+    if pdf_enabled:
+        selected_components.append("manual_pdf")
+        images["manual_pdf"] = _make_value(makefile, "MANUAL_PDF_IMAGE") or component_reference("manual_pdf")
+    if vega_enabled:
+        selected_components.append("vegavisuals")
+    if diagram_enabled:
+        selected_components.append("diavisuals")
+
+    for component_id, reference in images.items():
+        if is_mutable_reference(reference):
+            findings.append(
+                _finding(
+                    "UW-DIST-PROJECT-MUTABLE-PIN",
+                    "warning",
+                    "version tag or digest",
+                    reference,
+                    "Replace mutable runtime tags with a release tag or digest.",
+                    component_id=component_id,
+                )
+            )
+    return findings, project_state, images, list(dict.fromkeys(selected_components))
+
+
+def _docker_findings(images: dict[str, str]) -> list[dict[str, Any]]:
+    if not shutil.which("docker"):
+        return [_finding("UW-DIST-DOCKER-AVAILABLE", "info", "optional Docker CLI", "not installed", "Install Docker only when container-backed features are needed.")]
+    try:
+        version = run_process(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            timeout_seconds=5,
+        )
+    except OSError as exc:
+        return [_finding("UW-DIST-DOCKER-AVAILABLE", "warning", "reachable optional Docker daemon", str(exc), "Start Docker or rerun doctor without --docker.")]
+    if version.returncode != 0:
+        return [_finding("UW-DIST-DOCKER-AVAILABLE", "warning", "reachable optional Docker daemon", version.stderr.strip() or "unavailable", "Start Docker or rerun doctor without --docker.")]
+
+    findings = [_finding("UW-DIST-DOCKER-AVAILABLE", "info", "reachable optional Docker daemon", version.stdout.strip() or "available", "No action required.")]
+    for component_id, reference in images.items():
+        try:
+            inspected = run_process(
+                ["docker", "image", "inspect", reference, "--format", "{{.Id}}"],
+                timeout_seconds=5,
+            )
+        except OSError as exc:
+            findings.append(
+                _finding(
+                    "UW-DIST-IMAGE-PRESENCE",
+                    "warning",
+                    f"optional local image {reference}",
+                    str(exc),
+                    "Retry local inspection or prepare the image explicitly; doctor never pulls images.",
+                    component_id=component_id,
+                )
+            )
+            continue
+        present = inspected.returncode == 0
+        findings.append(
+            _finding(
+                "UW-DIST-IMAGE-PRESENCE",
+                "info",
+                f"optional local image {reference}",
+                inspected.stdout.strip() if present else "not present locally",
+                "No action required." if present else "Pull or build the image explicitly before using this feature; doctor never pulls images.",
+                component_id=component_id,
+            )
+        )
+    return findings
+
+
+def distribution_doctor(
+    *,
+    project: Path | None = None,
+    factory: Path | None = None,
+    check_docker: bool = False,
+) -> dict[str, Any]:
+    contract = distribution_contract()
+    pending_components = sorted(
+        component_id for component_id, selected in contract["components"].items()
+        if selected["release_status"] == "pending"
+    )
+    unavailable_components = sorted(
+        component_id for component_id, selected in contract["components"].items()
+        if selected["release_status"] == "unavailable"
+    )
+    findings = [
+        _finding(
+            "UW-DIST-COMPONENT-CONTRACT",
+            "info",
+            1,
+            contract["schema_version"],
+            "No action required.",
+        )
+    ]
+    for component_id in pending_components:
+        selected = contract["components"][component_id]
+        findings.append(_finding(
+            "UW-DIST-COMPANION-RELEASE-PENDING",
+            "warning",
+            f"published immutable release {selected['release']}",
+            "pending",
+            f"Use an explicitly selected current {component_id} checkout for compatibility; do not publish the modular release until the tag exists.",
+            component_id=component_id,
+        ))
+    for component_id in unavailable_components:
+        selected = contract["components"][component_id]
+        findings.append(_finding(
+            "UW-DIST-COMPANION-RELEASE-UNAVAILABLE",
+            "warning",
+            f"published immutable release {selected['release']}",
+            "unavailable",
+            f"Restore availability of the selected {component_id} release before publishing the modular release.",
+            component_id=component_id,
+        ))
+    selected_components = ["wheel"]
+    images: dict[str, str] = {}
+    if factory is None:
+        findings.append(
+            _finding(
+                "UW-DIST-WHEEL-MODE",
+                "info",
+                "factory checkout optional for package-only commands",
+                "limited wheel mode",
+                "Set UNALTRAWEB_FACTORY_DIR only for factory-backed MCP, build, computation, capture, PDF, or bibliometrics commands.",
+            )
+        )
+        factory_state = {"available": False, "path": "", "mode": "wheel"}
+    else:
+        factory = factory.expanduser().resolve()
+        factory_state = {"available": (factory / "mcp-factory.yml").is_file(), "path": str(factory), "mode": "factory"}
+        if factory_state["available"]:
+            findings.extend(_factory_findings(factory))
+            if project is None:
+                selected_components = list(contract["components"])
+                images = {
+                    component_id: str(value["reference"])
+                    for component_id, value in contract["components"].items()
+                    if value["kind"] == "container"
+                }
+        else:
+            findings.append(_finding("UW-DIST-FACTORY", "error", "mcp-factory.yml", str(factory), "Set UNALTRAWEB_FACTORY_DIR to a valid factory checkout."))
+
+    project_state: dict[str, Any] = {"supplied": False, "path": ""}
+    if project is not None:
+        project = project.expanduser().resolve()
+        project_findings, project_state, project_images, project_components = _project_findings(project)
+        findings.extend(project_findings)
+        images = project_images
+        selected_components = project_components
+
+    if check_docker:
+        findings.extend(_docker_findings(images))
+    else:
+        findings.append(_finding("UW-DIST-DOCKER-CHECK", "info", "optional local image inspection", "not requested", "Pass --docker to inspect selected local images without pulling."))
+
+    severities = {severity: sum(1 for item in findings if item["severity"] == severity) for severity in ["error", "warning", "info"]}
+    return {
+        "schema_version": DOCTOR_SCHEMA_VERSION,
+        "ok": severities["error"] == 0,
+        "release_ready": not pending_components and not unavailable_components and severities["error"] == 0,
+        "pending_releases": pending_components,
+        "unavailable_releases": unavailable_components,
+        "offline": True,
+        "mode": factory_state["mode"],
+        "limited": factory_state["mode"] == "wheel",
+        "release": contract["release"],
+        "receipt_contract": contract["receipt_contract"],
+        "wheel_contract": contract["wheel_contract"],
+        "components": contract["components"],
+        "selected_components": selected_components,
+        "factory": factory_state,
+        "project": project_state,
+        "docker": {"checked": check_docker, "images": images},
+        "summary": severities,
+        "findings": findings,
+    }

--- a/src/unaltraweb_mcp/mcp_server.py
+++ b/src/unaltraweb_mcp/mcp_server.py
@@ -4,6 +4,7 @@ import inspect
 from pathlib import Path
 from typing import Any
 
+from .distribution import distribution_doctor as inspect_distribution
 from . import site_tools as tools
 
 
@@ -67,10 +68,20 @@ def run_server(project: Path, factory: Path) -> None:
         function.__doc__ = str(spec["description"])
         return mcp.prompt()(function)
 
+    @mcp.resource("web://distribution")
+    def distribution_resource() -> str:
+        """Versioned component BOM and offline doctor findings for the current distribution and project."""
+        return tools.dumps(inspect_distribution(project=project, factory=factory))
+
     @mcp.resource("web://site-context")
     def site_context_resource() -> str:
         """Current unaltraweb site profile, features, content, bibliography, bibliometrics, and build state."""
         return tools.dumps(tools.site_context(project, factory))
+
+    @mcp.resource("web://site-doctor")
+    def site_doctor_resource() -> str:
+        """Offline distribution, project-contract, freshness, scaffold-drift, and override findings."""
+        return tools.dumps(tools.site_doctor(project, factory))
 
     @mcp.resource("web://starter-templates")
     def starter_templates_resource() -> str:
@@ -207,6 +218,11 @@ def run_server(project: Path, factory: Path) -> None:
         return _prompt_text(factory, "build_and_review") + suffix
 
     @mcp.tool()
+    def distribution_doctor(check_docker: bool = False) -> dict[str, Any]:
+        """Inspect component versions, project feature pins, and optionally local Docker image presence without pulling."""
+        return inspect_distribution(project=project, factory=factory, check_docker=check_docker)
+
+    @mcp.tool()
     def starter_templates() -> dict[str, Any]:
         """Return package-owned website scaffolds under the legacy starter inventory name."""
         return tools.starter_templates(factory)
@@ -232,9 +248,34 @@ def run_server(project: Path, factory: Path) -> None:
         return tools.site_context(project, factory)
 
     @mcp.tool()
+    def site_doctor() -> dict[str, Any]:
+        """Run the read-only offline distribution and project doctor with stable findings and remediation."""
+        return tools.site_doctor(project, factory)
+
+    @mcp.tool()
     def site_check(max_bibliometrics_age_days: int = 180) -> dict[str, Any]:
         """Run local profile, freshness, bibliography, bibliometrics, and build-state checks without network access."""
         return tools.site_check(project, factory, max_bibliometrics_age_days)
+
+    @mcp.tool()
+    def site_source_read(path: str) -> dict[str, Any]:
+        """Read one strictly allowed UTF-8 text source and return its SHA-256 for later CAS mutation."""
+        return tools.site_source_read(project, path)
+
+    @mcp.tool()
+    def site_source_write(path: str, content: str, expected_sha256: str = "", create_only: bool = False, dry_run: bool = True) -> dict[str, Any]:
+        """Dry-run or atomically create/update one allowed text source. Creates require create_only; updates require the exact prior SHA-256."""
+        return tools.site_source_write(project, path, content, expected_sha256=expected_sha256, create_only=create_only, dry_run=dry_run)
+
+    @mcp.tool()
+    def site_source_delete(path: str, expected_sha256: str, dry_run: bool = True, confirm_delete: bool = False) -> dict[str, Any]:
+        """Dry-run or delete one allowed source after exact SHA-256 and explicit confirmation. _config.yml and directories are never deleted."""
+        return tools.site_source_delete(project, path, expected_sha256=expected_sha256, dry_run=dry_run, confirm_delete=confirm_delete)
+
+    @mcp.tool()
+    def scaffold_sync(dry_run: bool = True, confirm_sync: bool = False) -> dict[str, Any]:
+        """Synchronize package-managed runtime files only when they still match their recorded scaffold baseline."""
+        return tools.scaffold_sync(project, dry_run=dry_run, confirm_sync=confirm_sync)
 
     @mcp.tool()
     def profile_check() -> dict[str, Any]:
@@ -377,6 +418,11 @@ def run_server(project: Path, factory: Path) -> None:
         return tools.build_health(project)
 
     @mcp.tool()
+    def html_audit() -> dict[str, Any]:
+        """Audit generated _site HTML locally without fetching external links."""
+        return tools.html_audit(project)
+
+    @mcp.tool()
     def preview_start(port: int = 4000, site_profile: str = "", timeout_seconds: float = 60.0) -> dict[str, Any]:
         """Start the single labelled Jekyll preview container for this project and wait for HTTP readiness."""
         return tools.preview_start(project, port=port, site_profile=site_profile, timeout_seconds=timeout_seconds)
@@ -392,8 +438,8 @@ def run_server(project: Path, factory: Path) -> None:
         return tools.preview_stop(project)
 
     @mcp.tool()
-    def http_check(base_url: str = "http://127.0.0.1:4000", paths: list[str] | None = None, timeout_seconds: float = 5.0) -> dict[str, Any]:
-        """Check whether a running Jekyll preview responds over HTTP. This does not make the MCP itself an HTTP server."""
-        return tools.http_check(base_url, paths=paths, timeout_seconds=timeout_seconds)
+    def http_check(paths: list[str] | None = None, timeout_seconds: float = 3.0) -> dict[str, Any]:
+        """Probe bounded local paths on this project's owned labelled preview without accepting an arbitrary origin or redirects."""
+        return tools.http_check(project, paths=paths, timeout_seconds=timeout_seconds)
 
     mcp.run()

--- a/src/unaltraweb_mcp/processes.py
+++ b/src/unaltraweb_mcp/processes.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+import selectors
+import signal
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_OUTPUT_LIMIT = 128 * 1024
+
+
+@dataclass(frozen=True)
+class ProcessResult:
+    args: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    timed_out: bool
+    stdout_truncated: bool
+    stderr_truncated: bool
+
+
+def run_process(
+    command: list[str],
+    *,
+    cwd: Path | str | None = None,
+    env: dict[str, str] | None = None,
+    timeout_seconds: float,
+    output_limit: int = DEFAULT_OUTPUT_LIMIT,
+) -> ProcessResult:
+    """Run a bounded child process and terminate its process group on timeout."""
+    if timeout_seconds <= 0:
+        raise ValueError("Process timeout must be positive.")
+    if output_limit <= 0:
+        raise ValueError("Process output limit must be positive.")
+
+    process = subprocess.Popen(
+        command,
+        cwd=str(cwd) if cwd is not None else None,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    assert process.stdout is not None
+    assert process.stderr is not None
+
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+    output = {"stdout": bytearray(), "stderr": bytearray()}
+    truncated = {"stdout": False, "stderr": False}
+    deadline = time.monotonic() + timeout_seconds
+    timed_out = False
+    terminate_deadline = 0.0
+    drain_deadline = float("inf")
+    killed = False
+
+    try:
+        while selector.get_map() or process.poll() is None:
+            now = time.monotonic()
+            if not timed_out and now >= deadline:
+                timed_out = True
+                terminate_deadline = now + 1.0
+                drain_deadline = now + 2.0
+                try:
+                    os.killpg(process.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+            elif timed_out and not killed and now >= terminate_deadline:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                if process.poll() is None:
+                    process.kill()
+                killed = True
+                drain_deadline = now + 1.0
+            elif timed_out and now >= drain_deadline and process.poll() is not None:
+                for key in list(selector.get_map().values()):
+                    selector.unregister(key.fileobj)
+                break
+
+            events = selector.select(0.05)
+            for key, _ in events:
+                stream = str(key.data)
+                try:
+                    chunk = os.read(key.fd, 65536)
+                except BlockingIOError:
+                    continue
+                if not chunk:
+                    selector.unregister(key.fileobj)
+                    continue
+                remaining = output_limit - len(output[stream])
+                if remaining > 0:
+                    output[stream].extend(chunk[:remaining])
+                if len(chunk) > remaining:
+                    truncated[stream] = True
+
+        try:
+            process.wait(timeout=1.0 if timed_out else None)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+    finally:
+        selector.close()
+        process.stdout.close()
+        process.stderr.close()
+
+    return ProcessResult(
+        args=list(command),
+        returncode=124 if timed_out else process.returncode,
+        stdout=output["stdout"].decode("utf-8", errors="replace"),
+        stderr=output["stderr"].decode("utf-8", errors="replace"),
+        timed_out=timed_out,
+        stdout_truncated=truncated["stdout"],
+        stderr_truncated=truncated["stderr"],
+    )

--- a/src/unaltraweb_mcp/scaffolds/common/Gemfile
+++ b/src/unaltraweb_mcp/scaffolds/common/Gemfile
@@ -1,3 +1,0 @@
-source "https://rubygems.org"
-
-gem "unaltraweb", "= 0.3.0"

--- a/src/unaltraweb_mcp/scaffolds/common/Gemfile.lock.tmpl
+++ b/src/unaltraweb_mcp/scaffolds/common/Gemfile.lock.tmpl
@@ -215,7 +215,7 @@ GEM
       date
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unaltraweb (0.3.0)
+    unaltraweb (__GEM_VERSION__)
       classifier-reborn
       css_parser
       feedjira
@@ -250,7 +250,7 @@ PLATFORMS
   x86_64-linux-gnu
 
 DEPENDENCIES
-  unaltraweb (= 0.3.0)
+  unaltraweb (= __GEM_VERSION__)
 
 CHECKSUMS
   activesupport (8.1.2)
@@ -349,7 +349,7 @@ CHECKSUMS
   terser (1.2.6)
   time (0.4.2)
   tzinfo (2.0.6)
-  unaltraweb (0.3.0)
+  unaltraweb (__GEM_VERSION__)
   unicode-display_width (2.6.0)
   uri (1.1.1)
   webrick (1.9.2)

--- a/src/unaltraweb_mcp/scaffolds/common/Gemfile.tmpl
+++ b/src/unaltraweb_mcp/scaffolds/common/Gemfile.tmpl
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "unaltraweb", "= __GEM_VERSION__"

--- a/src/unaltraweb_mcp/scaffolds/common/Makefile.tmpl
+++ b/src/unaltraweb_mcp/scaffolds/common/Makefile.tmpl
@@ -1,6 +1,6 @@
 LOCAL_CORE ?= /opt/unaltraweb
 LOCAL_GEMFILE := tmp/Gemfile.local
-MCP_IMAGE ?= ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0
+MCP_IMAGE ?= __MCP_IMAGE__
 UNALTRAWEB_CAPTURE_RUNTIME := 1
 LOCAL_UID ?= $(shell id -u)
 LOCAL_GID ?= $(shell id -g)
@@ -29,6 +29,7 @@ serve-capture-native: local-gemfile
 serve-native: site-check-native serve-capture-native
 
 test-native: build-native
+	@unaltraweb-mcp --project "$(CURDIR)" mcp html-audit >/dev/null
 
 build:
 	@docker run --rm --user "$(LOCAL_UID):$(LOCAL_GID)" -e HOME=/tmp -v "$(CURDIR):/workspace" -w /workspace --entrypoint make "$(MCP_IMAGE)" --silent build-native LOCAL_CORE=/opt/unaltraweb

--- a/src/unaltraweb_mcp/site_tools.py
+++ b/src/unaltraweb_mcp/site_tools.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
 import datetime as dt
+import difflib
+import fcntl
 import hashlib
 import json
 import os
 import re
-import subprocess
+import stat
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
+
+from .distribution import component, component_reference
+from .processes import ProcessResult, run_process
 
 try:
     import yaml  # type: ignore
@@ -43,6 +50,36 @@ FIGURE_WEB_FONT_MIN_PIXELS = MANUAL_WEB_BODY_FONT_PIXELS * 0.75
 FIGURE_WEB_FONT_MAX_PIXELS = MANUAL_WEB_BODY_FONT_PIXELS
 VEGA_SOURCE_SUFFIXES = (".vl.json", ".vg.json")
 WEB_CAPTURE_SUFFIXES = (".capture.yml", ".capture.yaml")
+MAKE_TIMEOUTS = {
+    "build-native": 900.0,
+    "manual-compute-status": 60.0,
+    "manual-compute-check": 120.0,
+    "manual-compute-render": 1800.0,
+    "manual-compute-render-figures": 1800.0,
+    "web-capture-status": 60.0,
+    "web-capture-check": 120.0,
+    "manual-pdf-build": 1800.0,
+    "manual-pdf-status": 60.0,
+    "manual-pdf-publish": 300.0,
+    "web-capture-render": 900.0,
+    "metrics-check": 120.0,
+    "metrics-scimago-fetch": 900.0,
+    "metrics-update": 900.0,
+    "metrics-update-all": 900.0,
+}
+DEFAULT_MAKE_TIMEOUT = 300.0
+WORKER_FACTORY_LABEL = "io.context.mcp-factory"
+WORKER_ROLE_LABEL = "io.context.mcp-role"
+WORKER_PROJECT_LABEL = "io.context.mcp-project"
+WORKER_TOKEN_LABEL = "io.context.mcp-worker-token"
+WORKER_TARGET_ROLES = {
+    "manual-compute-render": "computation",
+    "manual-compute-render-figures": "computation",
+    "web-capture-render": "web-capture",
+    "manual-pdf-status": "manual-pdf",
+    "manual-pdf-build": "manual-pdf",
+    "manual-pdf-publish": "manual-pdf",
+}
 PROMPT_SPECS: dict[str, dict[str, Any]] = {
     "start_site_session": {
         "source": "00-start-site-session.txt",
@@ -233,8 +270,28 @@ PROFILE_CONTRACTS: dict[str, dict[str, Any]] = {
     },
 }
 
-SCAFFOLD_TEMPLATE_FILES = {"_config.yml.tmpl", "home.md.tmpl"}
+SCAFFOLD_TEMPLATE_FILES = {"Gemfile.lock.tmpl", "Gemfile.tmpl", "Makefile.tmpl", "_config.yml.tmpl", "home.md.tmpl"}
+SCAFFOLD_MANIFEST_PATH = Path(".unaltraweb/scaffold.json")
+SCAFFOLD_MANAGED_PATHS = (
+    Path(".gitignore"),
+    Path("Makefile"),
+    Path("Gemfile"),
+    Path("Gemfile.lock"),
+    Path(".github/workflows/deploy.yml"),
+)
 LANGUAGE_RE = re.compile(r"^[a-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$")
+SITE_SOURCE_MAX_BYTES = 1024 * 1024
+SCAFFOLD_FILE_MAX_BYTES = 4 * 1024 * 1024
+HTML_AUDIT_FILE_MAX_BYTES = 32 * 1024 * 1024
+HTTP_RESPONSE_MAX_BYTES = 64 * 1024
+COMPANION_FILE_MAX_BYTES = 16 * 1024 * 1024
+COMPANION_JSON_MAX_DEPTH = 64
+COMPANION_JSON_MAX_NODES = 100_000
+SITE_SOURCE_DIFF_MAX_LINES = 200
+SITE_SOURCE_DIFF_MAX_BYTES = 32 * 1024
+SITE_SOURCE_CONTENT_SUFFIXES = {".md", ".markdown", ".html"}
+SITE_SOURCE_DATA_SUFFIXES = {".yml", ".yaml", ".json", ".csv"}
+SITE_SOURCE_CONTEXT_SUFFIXES = {".md", ".markdown"}
 
 
 def project_path(raw: str | Path | None) -> Path:
@@ -292,6 +349,8 @@ def _fallback_config_yaml(text: str) -> dict[str, Any]:
         while stack and indent <= stack[-1][0]:
             stack.pop()
         parent = stack[-1][1]
+        if key in parent:
+            raise ValueError(f"duplicate YAML key: {key}")
         if value:
             parent[key] = _parse_scalar(value)
         else:
@@ -301,27 +360,57 @@ def _fallback_config_yaml(text: str) -> dict[str, Any]:
     return data
 
 
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON number is not allowed: {value}")
+
+
+def _strict_json_loads(text: str) -> Any:
+    def unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError(f"duplicate JSON key: {key}")
+            value[key] = item
+        return value
+
+    return json.loads(text, parse_constant=_reject_json_constant, object_pairs_hook=unique_object)
+
+
 def load_yaml_text(text: str) -> Any:
-    if yaml is not None:
-        parsed = yaml.safe_load(text)
-        return parsed if parsed is not None else {}
-    return _fallback_config_yaml(text)
+    if yaml is None:
+        return _fallback_config_yaml(text)
+
+    class UniqueKeyLoader(yaml.SafeLoader):
+        pass
+
+    def construct_mapping(loader, node, deep=False):
+        mapping: dict[Any, Any] = {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            if key in mapping:
+                raise ValueError(f"duplicate YAML key: {key}")
+            mapping[key] = loader.construct_object(value_node, deep=deep)
+        return mapping
+
+    UniqueKeyLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping)
+    parsed = yaml.load(text, Loader=UniqueKeyLoader)
+    return parsed if parsed is not None else {}
 
 
 def load_yaml_file(path: Path) -> dict[str, Any]:
     if not path.is_file():
         return {}
     try:
-        parsed = load_yaml_text(path.read_text(encoding="utf-8"))
-    except Exception:
+        parsed = load_yaml_text(_read_regular_path(path, max_bytes=SITE_SOURCE_MAX_BYTES, description=f"YAML file {path}").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError, RuntimeError):
         return {}
     return parsed if isinstance(parsed, dict) else {}
 
 
 def read_front_matter(path: Path) -> dict[str, Any]:
     try:
-        text = path.read_text(encoding="utf-8", errors="ignore")
-    except OSError:
+        text = _read_regular_path(path, max_bytes=COMPANION_FILE_MAX_BYTES, description=f"Content source {path}").decode("utf-8", errors="ignore")
+    except (OSError, ValueError, RuntimeError):
         return {}
     if not text.startswith("---"):
         return {}
@@ -530,14 +619,14 @@ def scaffold_inventory() -> dict[str, Any]:
     return {
         "source": "unaltraweb_mcp package",
         "default": "unaltreselfie",
-        "common_available": (root / "common" / "Makefile").is_file() and (root / "common" / "Gemfile").is_file(),
+        "common_available": (root / "common" / "Makefile.tmpl").is_file() and (root / "common" / "Gemfile.tmpl").is_file(),
         "profiles": profiles,
     }
 
 
-def starter_templates(factory: Path) -> dict[str, Any]:
+def starter_templates(factory: Path | None = None) -> dict[str, Any]:
     """Return the package-owned scaffolds exposed by the legacy inventory name."""
-    return {"factory": str(project_path(factory)), **scaffold_inventory()}
+    return {"factory": str(project_path(factory)) if factory else "", **scaffold_inventory()}
 
 
 def _yaml_scalar(value: str) -> str:
@@ -574,7 +663,7 @@ def _scaffold_payloads(profile: str, *, title: str, baseurl: str, url: str, defa
     root = _scaffold_root()
     common_root = root / "common"
     profile_root = root / "profiles" / profile
-    required = [common_root / "Makefile", common_root / "Gemfile", profile_root / "_config.yml.tmpl", profile_root / "home.md.tmpl"]
+    required = [common_root / "Makefile.tmpl", common_root / "Gemfile.tmpl", common_root / "Gemfile.lock.tmpl", profile_root / "_config.yml.tmpl", profile_root / "home.md.tmpl"]
     missing = [str(path) for path in required if not path.is_file()]
     if missing:
         raise RuntimeError(f"Package-owned new-web scaffold is incomplete: {', '.join(missing)}")
@@ -598,6 +687,12 @@ def _scaffold_payloads(profile: str, *, title: str, baseurl: str, url: str, defa
         "DEFAULT_LANG": _yaml_scalar(default_lang),
         "LANGUAGES": _yaml_inline_list(languages),
     }
+    common_replacements = {
+        "GEM_VERSION": str(component("gem")["version"]),
+        "MCP_IMAGE": component_reference("mcp"),
+    }
+    for name in ["Makefile", "Gemfile", "Gemfile.lock"]:
+        payloads[Path(name)] = _render_scaffold_template(common_root / f"{name}.tmpl", common_replacements)
     payloads[Path("_config.yml")] = _render_scaffold_template(profile_root / "_config.yml.tmpl", replacements)
     for language in languages:
         home_replacements = {
@@ -606,7 +701,40 @@ def _scaffold_payloads(profile: str, *, title: str, baseurl: str, url: str, defa
             "PERMALINK": _yaml_scalar("/" if language == default_lang else f"/{language}/"),
         }
         payloads[Path("_pages") / language / "index.md"] = _render_scaffold_template(profile_root / "home.md.tmpl", home_replacements)
+    payloads[SCAFFOLD_MANIFEST_PATH] = _scaffold_manifest_bytes(
+        {path.as_posix(): _source_hash(payloads[path]) for path in SCAFFOLD_MANAGED_PATHS}
+    )
     return payloads
+
+
+def _managed_scaffold_payloads() -> dict[Path, bytes]:
+    common_root = _scaffold_root() / "common"
+    payloads = {
+        Path(".gitignore"): (common_root / ".gitignore").read_bytes(),
+        Path(".github/workflows/deploy.yml"): (common_root / ".github/workflows/deploy.yml").read_bytes(),
+    }
+    replacements = {
+        "GEM_VERSION": str(component("gem")["version"]),
+        "MCP_IMAGE": component_reference("mcp"),
+    }
+    for name in ["Makefile", "Gemfile", "Gemfile.lock"]:
+        payloads[Path(name)] = _render_scaffold_template(common_root / f"{name}.tmpl", replacements)
+    return payloads
+
+
+def _scaffold_manifest_bytes(files: dict[str, str]) -> bytes:
+    return (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "source": "unaltraweb_mcp package",
+                "files": dict(sorted(files.items())),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
 
 
 def _scaffold_preflight(project: Path, payloads: dict[Path, bytes], required_directories: set[Path]) -> tuple[list[Path], list[Path]]:
@@ -655,10 +783,16 @@ def _scaffold_preflight(project: Path, payloads: dict[Path, bytes], required_dir
         if target.exists():
             if not target.is_file():
                 conflicts.append(f"expected a file but found a directory: {relative}")
-            elif target.read_bytes() == content:
-                unchanged.append(relative)
             else:
-                conflicts.append(f"existing file differs from the package scaffold: {relative}")
+                try:
+                    current = _read_regular_path(target, max_bytes=SCAFFOLD_FILE_MAX_BYTES, description=f"Scaffold target {relative}")
+                except (OSError, ValueError, RuntimeError) as exc:
+                    conflicts.append(f"existing file is unsafe or unreadable: {relative}: {exc}")
+                else:
+                    if current == content:
+                        unchanged.append(relative)
+                    else:
+                        conflicts.append(f"existing file differs from the package scaffold: {relative}")
         else:
             create.append(relative)
 
@@ -748,19 +882,56 @@ def _create_scaffold_file(root_fd: int, relative: Path, content: bytes) -> None:
         os.close(parent_fd)
 
 
-def _read_scaffold_file(root_fd: int, relative: Path) -> bytes:
-    parent_fd = _open_scaffold_directory(root_fd, relative.parent, create=False)
+def _read_regular_at(parent_fd: int, name: str, *, max_bytes: int, description: str) -> tuple[bytes, os.stat_result]:
     file_fd: int | None = None
     try:
-        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-        file_fd = os.open(relative.name, flags, dir_fd=parent_fd)
-        chunks = []
-        while chunk := os.read(file_fd, 65536):
-            chunks.append(chunk)
-        return b"".join(chunks)
+        flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOFOLLOW", 0)
+        file_fd = os.open(name, flags, dir_fd=parent_fd)
+        metadata = os.fstat(file_fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError(f"{description} must be a regular file, not a directory or special file.")
+        if metadata.st_size > max_bytes:
+            raise ValueError(f"{description} exceeds the {max_bytes}-byte limit.")
+        content = bytearray()
+        while len(content) <= max_bytes:
+            chunk = os.read(file_fd, min(65536, max_bytes + 1 - len(content)))
+            if not chunk:
+                break
+            content.extend(chunk)
+        if len(content) > max_bytes:
+            raise ValueError(f"{description} exceeds the {max_bytes}-byte limit.")
+        final_metadata = os.fstat(file_fd)
+        before = (metadata.st_dev, metadata.st_ino, metadata.st_size, metadata.st_mtime_ns, metadata.st_ctime_ns)
+        after = (final_metadata.st_dev, final_metadata.st_ino, final_metadata.st_size, final_metadata.st_mtime_ns, final_metadata.st_ctime_ns)
+        if before != after:
+            raise RuntimeError(f"{description} changed while it was being read.")
+        return bytes(content), final_metadata
     finally:
         if file_fd is not None:
             os.close(file_fd)
+
+
+def _read_regular_path(path: Path, *, max_bytes: int, description: str) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    parent_fd = os.open(path.parent, flags)
+    try:
+        content, _ = _read_regular_at(parent_fd, path.name, max_bytes=max_bytes, description=description)
+        return content
+    finally:
+        os.close(parent_fd)
+
+
+def _read_scaffold_file(root_fd: int, relative: Path) -> bytes:
+    parent_fd = _open_scaffold_directory(root_fd, relative.parent, create=False)
+    try:
+        content, _ = _read_regular_at(
+            parent_fd,
+            relative.name,
+            max_bytes=SCAFFOLD_FILE_MAX_BYTES,
+            description=f"Scaffold file {relative}",
+        )
+        return content
+    finally:
         os.close(parent_fd)
 
 
@@ -798,7 +969,10 @@ def new_web(
         for relative in sorted(required_directories):
             directory_fd = _open_scaffold_directory(root_fd, relative, create=True)
             os.close(directory_fd)
-        for relative in create:
+        ordered_create = [relative for relative in create if relative != SCAFFOLD_MANIFEST_PATH]
+        if SCAFFOLD_MANIFEST_PATH in create:
+            ordered_create.append(SCAFFOLD_MANIFEST_PATH)
+        for relative in ordered_create:
             _create_scaffold_file(root_fd, relative, payloads[relative])
         for relative, content in sorted(payloads.items()):
             if _read_scaffold_file(root_fd, relative) != content:
@@ -824,6 +998,348 @@ def new_web(
         "profile_check": check,
         "next_steps": ["Edit the generated configuration and home page", "Run site_check", "Run build_site"],
     }
+
+
+def _scaffold_sync_plan(project: Path) -> dict[str, Any]:
+    root_fd = _open_project_root(project)
+    try:
+        try:
+            manifest_content = _read_scaffold_file(root_fd, SCAFFOLD_MANIFEST_PATH)
+        except (OSError, ValueError, RuntimeError) as exc:
+            raise RuntimeError(
+                "Scaffold baseline is missing or unsafe; scaffold_sync only manages sites created with a package baseline."
+            ) from exc
+        if len(manifest_content) > SITE_SOURCE_MAX_BYTES or b"\x00" in manifest_content:
+            raise RuntimeError("Scaffold baseline exceeds the text manifest safety limits.")
+        try:
+            manifest = _strict_json_loads(manifest_content.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+            raise RuntimeError("Scaffold baseline is not valid UTF-8 JSON.") from exc
+        files = manifest.get("files") if isinstance(manifest, dict) else None
+        if not isinstance(manifest, dict) or manifest.get("schema_version") != 1 or not isinstance(files, dict):
+            raise RuntimeError("Unsupported or invalid scaffold baseline schema.")
+        baseline: dict[str, str] = {}
+        for raw_path, raw_hash in files.items():
+            path = str(raw_path)
+            digest = str(raw_hash)
+            relative = Path(path)
+            if not path or relative.is_absolute() or any(part in {"", ".", ".."} for part in relative.parts):
+                raise RuntimeError(f"Invalid scaffold baseline path: {path}.")
+            if not re.fullmatch(r"[0-9a-f]{64}", digest):
+                raise RuntimeError(f"Invalid scaffold baseline SHA-256 for {path}.")
+            baseline[path] = digest
+
+        payloads = _managed_scaffold_payloads()
+        creates: list[dict[str, str]] = []
+        updates: list[dict[str, str]] = []
+        unchanged: list[str] = []
+        adopted: list[str] = []
+        conflicts: list[dict[str, str]] = []
+        for relative in SCAFFOLD_MANAGED_PATHS:
+            path = relative.as_posix()
+            package_hash = _source_hash(payloads[relative])
+            baseline_hash = baseline.get(path, "")
+            try:
+                current = _read_scaffold_file(root_fd, relative)
+            except FileNotFoundError:
+                current = None
+            except (OSError, ValueError, RuntimeError) as exc:
+                conflicts.append({"path": path, "reason": f"managed path is unsafe or unreadable: {exc}"})
+                continue
+            current_hash = _source_hash(current) if current is not None else ""
+
+            if baseline_hash:
+                if current is None:
+                    conflicts.append({"path": path, "reason": "managed file recorded by the baseline is missing"})
+                elif current_hash != baseline_hash:
+                    conflicts.append({"path": path, "reason": "local file differs from its recorded baseline"})
+                elif current_hash == package_hash:
+                    unchanged.append(path)
+                else:
+                    updates.append({"path": path, "expected_sha256": current_hash, "sha256": package_hash})
+            elif current is None:
+                creates.append({"path": path, "sha256": package_hash})
+            elif current_hash == package_hash:
+                adopted.append(path)
+            else:
+                conflicts.append({"path": path, "reason": "new package-managed path already exists with different content"})
+
+        retired = sorted(path for path in baseline if path not in {item.as_posix() for item in SCAFFOLD_MANAGED_PATHS})
+        next_baseline = dict(baseline)
+        next_baseline.update({path.as_posix(): _source_hash(payloads[path]) for path in SCAFFOLD_MANAGED_PATHS})
+        next_manifest = _scaffold_manifest_bytes(next_baseline)
+        return {
+            "ok": not conflicts,
+            "project": str(project),
+            "creates": creates,
+            "updates": updates,
+            "unchanged": unchanged,
+            "adopted": adopted,
+            "retired": retired,
+            "conflicts": conflicts,
+            "manifest_update": next_manifest != manifest_content,
+            "_payloads": payloads,
+            "_manifest": next_manifest,
+            "_manifest_sha256": _source_hash(manifest_content),
+        }
+    finally:
+        os.close(root_fd)
+
+
+def _stage_managed_write(root_fd: int, relative: Path, content: bytes) -> dict[str, Any]:
+    parent_fd = _open_scaffold_directory(root_fd, relative.parent, create=True)
+    temporary = f".unaltraweb-scaffold-stage-{os.getpid()}-{time.time_ns()}"
+    temp_fd: int | None = None
+    try:
+        temp_fd = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o644,
+            dir_fd=parent_fd,
+        )
+        _write_all(temp_fd, content)
+        os.fsync(temp_fd)
+        return {"relative": relative, "parent_fd": parent_fd, "temporary": temporary, "content": content}
+    except Exception:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        os.close(parent_fd)
+        raise
+    finally:
+        if temp_fd is not None:
+            os.close(temp_fd)
+
+
+def _commit_staged_managed_write(staged: dict[str, Any], *, expected_sha256: str = "") -> dict[str, Any]:
+    relative: Path = staged["relative"]
+    parent_fd: int = staged["parent_fd"]
+    temporary: str = staged["temporary"]
+    backup = f".unaltraweb-scaffold-backup-{os.getpid()}-{time.time_ns()}"
+    backup_present = False
+    installed_identity: tuple[int, int] | None = None
+    try:
+        if expected_sha256:
+            current, metadata = _read_source_at(parent_fd, relative.name)
+            path_metadata = os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False)
+            if _source_hash(current) != expected_sha256 or _path_identity(metadata) != _path_identity(path_metadata):
+                raise RuntimeError(f"Managed file changed in the final scaffold_sync window: {relative}")
+            os.chmod(temporary, stat.S_IMODE(metadata.st_mode), dir_fd=parent_fd, follow_symlinks=False)
+            os.rename(relative.name, backup, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            backup_present = True
+            moved, moved_metadata = _read_source_at(parent_fd, backup)
+            if _source_hash(moved) != expected_sha256 or _path_identity(moved_metadata) != _path_identity(metadata):
+                _restore_private_backup(parent_fd, relative.name, backup, None)
+                backup_present = False
+                raise RuntimeError(f"Managed file changed in the final scaffold_sync window: {relative}")
+        try:
+            os.link(temporary, relative.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd, follow_symlinks=False)
+        except FileExistsError as exc:
+            if backup_present:
+                _restore_private_backup(parent_fd, relative.name, backup, None)
+                backup_present = False
+            raise RuntimeError(f"Managed path appeared during scaffold_sync apply: {relative}") from exc
+        installed_identity = _path_identity(os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False))
+        if backup_present:
+            after, after_metadata = _read_source_at(parent_fd, backup)
+            if _source_hash(after) != expected_sha256 or _path_identity(after_metadata) != _path_identity(metadata):
+                _restore_private_backup(parent_fd, relative.name, backup, installed_identity)
+                backup_present = False
+                installed_identity = None
+                raise RuntimeError(f"Managed file changed in the final scaffold_sync window: {relative}")
+        os.unlink(temporary, dir_fd=parent_fd)
+        staged["temporary"] = ""
+        os.fsync(parent_fd)
+        return {
+            "relative": relative,
+            "parent_fd": parent_fd,
+            "backup": backup if backup_present else "",
+            "installed_identity": installed_identity,
+            "installed_sha256": _source_hash(staged["content"]),
+            "expected_sha256": expected_sha256,
+        }
+    except Exception:
+        if backup_present:
+            _restore_private_backup(parent_fd, relative.name, backup, installed_identity)
+        elif installed_identity is not None:
+            _unlink_if_identity(parent_fd, relative.name, installed_identity)
+        raise
+
+
+def _rollback_managed_transaction(applied: list[dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    for record in reversed(applied):
+        parent_fd = record["parent_fd"]
+        relative: Path = record["relative"]
+        try:
+            try:
+                installed, installed_metadata = _read_source_at(parent_fd, relative.name)
+            except FileNotFoundError:
+                pass
+            else:
+                if _path_identity(installed_metadata) != record["installed_identity"] or _source_hash(installed) != record["installed_sha256"]:
+                    raise RuntimeError("installed path changed after apply; preserving it and the private backup")
+                os.unlink(relative.name, dir_fd=parent_fd)
+            if record["backup"]:
+                _restore_private_backup(parent_fd, relative.name, record["backup"], None)
+                record["backup"] = ""
+            os.fsync(parent_fd)
+        except Exception as exc:
+            errors.append(f"{relative}: {exc}")
+    return errors
+
+
+def _verify_applied_managed_transaction(applied: list[dict[str, Any]]) -> None:
+    for record in applied:
+        parent_fd = record["parent_fd"]
+        relative: Path = record["relative"]
+        installed, installed_metadata = _read_source_at(parent_fd, relative.name)
+        if _path_identity(installed_metadata) != record["installed_identity"] or _source_hash(installed) != record["installed_sha256"]:
+            raise RuntimeError(f"Managed file changed before scaffold_sync commit: {relative}")
+        if record["backup"]:
+            backup, _ = _read_source_at(parent_fd, record["backup"])
+            if _source_hash(backup) != record["expected_sha256"]:
+                raise RuntimeError(f"Managed backup changed before scaffold_sync commit: {relative}")
+
+
+def _cleanup_staged_managed_writes(staged_files: list[dict[str, Any]]) -> None:
+    first_error: OSError | None = None
+    for staged in staged_files:
+        parent_fd = staged["parent_fd"]
+        temporary = staged.get("temporary", "")
+        try:
+            if temporary:
+                try:
+                    os.unlink(temporary, dir_fd=parent_fd)
+                except FileNotFoundError:
+                    pass
+        except OSError as exc:
+            first_error = first_error or exc
+        finally:
+            os.close(parent_fd)
+    if first_error is not None:
+        raise first_error
+
+
+def _recheck_scaffold_sync(root_fd: int, plan: dict[str, Any]) -> None:
+    for item in plan["creates"]:
+        relative = Path(item["path"])
+        parent_fd: int | None = None
+        try:
+            parent_fd = _open_scaffold_directory(root_fd, relative.parent, create=False)
+            try:
+                os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                continue
+            raise RuntimeError(f"Managed path appeared after scaffold_sync preflight: {relative}")
+        except FileNotFoundError:
+            continue
+        finally:
+            if parent_fd is not None:
+                os.close(parent_fd)
+    for item in plan["updates"]:
+        current = _read_scaffold_file(root_fd, Path(item["path"]))
+        if _source_hash(current) != item["expected_sha256"]:
+            raise RuntimeError(f"Managed file changed after scaffold_sync preflight: {item['path']}")
+    for path in [*plan["unchanged"], *plan["adopted"]]:
+        current = _read_scaffold_file(root_fd, Path(path))
+        if _source_hash(current) != _source_hash(plan["_payloads"][Path(path)]):
+            raise RuntimeError(f"Managed file changed after scaffold_sync preflight: {path}")
+    manifest = _read_scaffold_file(root_fd, SCAFFOLD_MANIFEST_PATH)
+    if _source_hash(manifest) != plan["_manifest_sha256"]:
+        raise RuntimeError("Scaffold baseline changed after scaffold_sync preflight.")
+
+
+def _recheck_scaffold_sync_before_manifest(root_fd: int, plan: dict[str, Any]) -> None:
+    for path in [*plan["unchanged"], *plan["adopted"]]:
+        current = _read_scaffold_file(root_fd, Path(path))
+        if _source_hash(current) != _source_hash(plan["_payloads"][Path(path)]):
+            raise RuntimeError(f"Managed file changed before scaffold_sync manifest commit: {path}")
+    manifest = _read_scaffold_file(root_fd, SCAFFOLD_MANIFEST_PATH)
+    if _source_hash(manifest) != plan["_manifest_sha256"]:
+        raise RuntimeError("Scaffold baseline changed before scaffold_sync manifest commit.")
+
+
+def _verify_scaffold_sync_committed(root_fd: int, plan: dict[str, Any]) -> None:
+    for path in [*plan["unchanged"], *plan["adopted"]]:
+        current = _read_scaffold_file(root_fd, Path(path))
+        if _source_hash(current) != _source_hash(plan["_payloads"][Path(path)]):
+            raise RuntimeError(f"Managed file changed during scaffold_sync manifest commit: {path}")
+    manifest = _read_scaffold_file(root_fd, SCAFFOLD_MANIFEST_PATH)
+    if _source_hash(manifest) != _source_hash(plan["_manifest"]):
+        raise RuntimeError("Scaffold baseline changed during scaffold_sync manifest commit.")
+
+
+def scaffold_sync(
+    project: Path,
+    *,
+    dry_run: bool = True,
+    confirm_sync: bool = False,
+) -> dict[str, Any]:
+    project = project_path(project)
+    plan = _scaffold_sync_plan(project)
+    public_plan = {key: value for key, value in plan.items() if not key.startswith("_")}
+    if plan["conflicts"]:
+        return {**public_plan, "dry_run": dry_run, "applied": False}
+    if dry_run:
+        return {**public_plan, "dry_run": True, "applied": False}
+    if not confirm_sync:
+        raise RuntimeError("A real scaffold synchronization requires confirm_sync=True after reviewing the dry-run.")
+
+    root_fd = _open_project_root(project)
+    staged_files: list[dict[str, Any]] = []
+    applied: list[dict[str, Any]] = []
+    committed = False
+    try:
+        fcntl.flock(root_fd, fcntl.LOCK_EX)
+        operations = [
+            (Path(item["path"]), plan["_payloads"][Path(item["path"])], "", False)
+            for item in plan["creates"]
+        ] + [
+            (Path(item["path"]), plan["_payloads"][Path(item["path"])], item["expected_sha256"], False)
+            for item in plan["updates"]
+        ]
+        if plan["manifest_update"]:
+            operations.append((SCAFFOLD_MANIFEST_PATH, plan["_manifest"], plan["_manifest_sha256"], True))
+        for relative, content, expected_sha256, manifest in operations:
+            staged = _stage_managed_write(root_fd, relative, content)
+            staged["expected_sha256"] = expected_sha256
+            staged["manifest"] = manifest
+            staged_files.append(staged)
+        _recheck_scaffold_sync(root_fd, plan)
+        for staged in (item for item in staged_files if not item["manifest"]):
+            applied.append(_commit_staged_managed_write(staged, expected_sha256=staged["expected_sha256"]))
+        _verify_applied_managed_transaction(applied)
+        _recheck_scaffold_sync_before_manifest(root_fd, plan)
+        for staged in (item for item in staged_files if item["manifest"]):
+            applied.append(_commit_staged_managed_write(staged, expected_sha256=staged["expected_sha256"]))
+        _verify_applied_managed_transaction(applied)
+        _verify_scaffold_sync_committed(root_fd, plan)
+        committed = True
+    except Exception as exc:
+        rollback_errors = _rollback_managed_transaction(applied)
+        if rollback_errors:
+            raise RuntimeError(f"scaffold_sync failed and rollback was incomplete: {'; '.join(rollback_errors)}") from exc
+        raise
+    finally:
+        try:
+            if committed:
+                for record in applied:
+                    if record["backup"]:
+                        try:
+                            os.unlink(record["backup"], dir_fd=record["parent_fd"])
+                        except FileNotFoundError:
+                            pass
+                        record["backup"] = ""
+                        os.fsync(record["parent_fd"])
+        finally:
+            try:
+                _cleanup_staged_managed_writes(staged_files)
+            finally:
+                fcntl.flock(root_fd, fcntl.LOCK_UN)
+                os.close(root_fd)
+    return {**public_plan, "dry_run": False, "applied": True}
 
 
 def initialize_site(
@@ -895,16 +1411,52 @@ def profile_prune_plan(project: Path, site_profile_value: str = "") -> dict[str,
 
 def _remove_empty_content_dirs(project: Path) -> list[str]:
     removed: list[str] = []
-    roots = [(project / directory).resolve() for directory in CONTENT_DIRS]
-    for root in roots:
-        if not root.is_dir():
-            continue
-        for directory in sorted((path for path in root.rglob("*") if path.is_dir()), key=lambda item: len(item.parts), reverse=True):
+
+    def remove_children(parent_fd: int, relative: Path) -> None:
+        try:
+            names = sorted(os.listdir(parent_fd))
+        except OSError:
+            return
+        for name in names:
             try:
-                directory.rmdir()
+                metadata = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
             except OSError:
                 continue
-            removed.append(rel(project, directory))
+            if not stat.S_ISDIR(metadata.st_mode):
+                continue
+            try:
+                child_fd = os.open(
+                    name,
+                    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+                    dir_fd=parent_fd,
+                )
+            except OSError:
+                continue
+            try:
+                remove_children(child_fd, relative / name)
+            finally:
+                os.close(child_fd)
+            try:
+                os.rmdir(name, dir_fd=parent_fd)
+            except OSError:
+                continue
+            removed.append((relative / name).as_posix())
+
+    root_fd = _open_project_root(project)
+    try:
+        fcntl.flock(root_fd, fcntl.LOCK_EX)
+        for root_name in CONTENT_DIRS:
+            try:
+                collection_fd = _open_scaffold_directory(root_fd, Path(root_name), create=False)
+            except OSError:
+                continue
+            try:
+                remove_children(collection_fd, Path(root_name))
+            finally:
+                os.close(collection_fd)
+    finally:
+        fcntl.flock(root_fd, fcntl.LOCK_UN)
+        os.close(root_fd)
     return removed
 
 
@@ -918,13 +1470,34 @@ def profile_prune(project: Path, site_profile_value: str = "", *, dry_run: bool 
 
     deleted: list[str] = []
     skipped: list[dict[str, str]] = []
-    for item in plan["candidates"]:
-        target = _safe_relative_path(project, str(item["path"]), default="")
-        if not target.is_file():
-            skipped.append({"path": str(item["path"]), "reason": "not a file"})
-            continue
-        target.unlink()
-        deleted.append(str(item["path"]))
+    root_fd = _open_project_root(project)
+    try:
+        fcntl.flock(root_fd, fcntl.LOCK_EX)
+        for item in plan["candidates"]:
+            raw_path = str(item["path"])
+            relative = Path(raw_path)
+            if not relative.parts or relative.is_absolute() or any(part in {"", ".", ".."} for part in relative.parts) or relative.parts[0] not in CONTENT_DIRS:
+                skipped.append({"path": raw_path, "reason": "unsafe content path"})
+                continue
+            parent_fd: int | None = None
+            try:
+                parent_fd = _open_scaffold_directory(root_fd, relative.parent, create=False)
+                metadata = os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False)
+                if not stat.S_ISREG(metadata.st_mode):
+                    skipped.append({"path": raw_path, "reason": "not a regular file"})
+                    continue
+                os.unlink(relative.name, dir_fd=parent_fd)
+                os.fsync(parent_fd)
+            except OSError as exc:
+                skipped.append({"path": raw_path, "reason": f"unsafe, missing, or changed path: {exc}"})
+                continue
+            finally:
+                if parent_fd is not None:
+                    os.close(parent_fd)
+            deleted.append(raw_path)
+    finally:
+        fcntl.flock(root_fd, fcntl.LOCK_UN)
+        os.close(root_fd)
 
     return {
         "ok": True,
@@ -960,8 +1533,10 @@ def _computation_front_matter_for_typography(source: Path) -> dict[str, Any]:
         return read_front_matter(source)
     if source.suffix.lower() == ".ipynb":
         try:
-            notebook = json.loads(source.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            notebook = _strict_json_loads(
+                _read_regular_path(source, max_bytes=COMPANION_FILE_MAX_BYTES, description=f"Notebook source {source}").decode("utf-8")
+            )
+        except (OSError, UnicodeDecodeError, ValueError, RuntimeError, json.JSONDecodeError):
             return {}
         value = notebook.get("metadata", {}).get("unaltraweb_front_matter")
         if isinstance(value, dict):
@@ -2305,6 +2880,397 @@ def _safe_relative_path(project: Path, raw_path: str, *, default: str) -> Path:
     return resolved
 
 
+def _site_source_relative(raw_path: str) -> Path:
+    if not raw_path or "\\" in raw_path or "\x00" in raw_path:
+        raise ValueError("Source path must be a non-empty project-relative POSIX path.")
+    relative = Path(raw_path)
+    if relative.is_absolute() or any(part in {"", ".", ".."} for part in relative.parts):
+        raise ValueError("Source path must be a confined project-relative path without traversal.")
+    suffix = relative.suffix.lower()
+    allowed = relative == Path("_config.yml")
+    allowed = allowed or (
+        len(relative.parts) >= 2
+        and relative.parts[0] in CONTENT_DIRS
+        and suffix in SITE_SOURCE_CONTENT_SUFFIXES
+    )
+    allowed = allowed or (
+        len(relative.parts) >= 2
+        and relative.parts[0] == "_data"
+        and suffix in SITE_SOURCE_DATA_SUFFIXES
+    )
+    allowed = allowed or (
+        len(relative.parts) >= 2
+        and relative.parts[0] == "context"
+        and suffix in SITE_SOURCE_CONTEXT_SUFFIXES
+    )
+    if not allowed:
+        raise ValueError(
+            "Source path is not an allowed text source (_config.yml, a Markdown/HTML content collection, "
+            "YAML/JSON/CSV under _data, or Markdown under context)."
+        )
+    return relative
+
+
+def _open_project_root(project: Path) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        return os.open(project, flags)
+    except OSError as exc:
+        raise RuntimeError(f"Could not open the project root safely: {project}: {exc}") from exc
+
+
+def _read_source_at(parent_fd: int, name: str) -> tuple[bytes, os.stat_result]:
+    return _read_regular_at(
+        parent_fd,
+        name,
+        max_bytes=SITE_SOURCE_MAX_BYTES,
+        description="Source path",
+    )
+
+
+def _read_source_from_root(root_fd: int, relative: Path) -> tuple[bytes, os.stat_result]:
+    parent_fd: int | None = None
+    try:
+        parent_fd = _open_scaffold_directory(root_fd, relative.parent, create=False)
+        return _read_source_at(parent_fd, relative.name)
+    except OSError as exc:
+        raise RuntimeError(f"Could not read source path safely: {relative}: {exc}") from exc
+    finally:
+        if parent_fd is not None:
+            os.close(parent_fd)
+
+
+def _decode_site_source(relative: Path, content: bytes) -> str:
+    if len(content) > SITE_SOURCE_MAX_BYTES:
+        raise ValueError(f"Source content exceeds the {SITE_SOURCE_MAX_BYTES}-byte limit.")
+    if b"\x00" in content:
+        raise ValueError("Source content must not contain NUL bytes.")
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("Source content must be valid UTF-8.") from exc
+
+    suffix = relative.suffix.lower()
+    try:
+        if relative == Path("_config.yml") or suffix in {".yml", ".yaml"}:
+            parsed = load_yaml_text(text)
+            if relative == Path("_config.yml") and not isinstance(parsed, dict):
+                raise ValueError("_config.yml must contain a YAML mapping.")
+        elif suffix == ".json":
+            _strict_json_loads(text)
+    except ValueError:
+        raise
+    except Exception as exc:
+        kind = "JSON" if suffix == ".json" else "YAML"
+        raise ValueError(f"Source content is not valid whole-file {kind}: {exc}") from exc
+    return text
+
+
+def _source_hash(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _expected_source_hash(value: str) -> str:
+    if not re.fullmatch(r"[0-9a-f]{64}", value):
+        raise ValueError("expected_sha256 must be an exact lowercase SHA-256 digest.")
+    return value
+
+
+def _bounded_source_diff(relative: Path, current: str, proposed: str) -> dict[str, Any]:
+    lines = list(
+        difflib.unified_diff(
+            current.splitlines(keepends=True),
+            proposed.splitlines(keepends=True),
+            fromfile=f"a/{relative}",
+            tofile=f"b/{relative}",
+        )
+    )
+    selected = lines[:SITE_SOURCE_DIFF_MAX_LINES]
+    text = "".join(selected)
+    encoded = text.encode("utf-8")
+    truncated = len(lines) > len(selected) or len(encoded) > SITE_SOURCE_DIFF_MAX_BYTES
+    if len(encoded) > SITE_SOURCE_DIFF_MAX_BYTES:
+        text = encoded[:SITE_SOURCE_DIFF_MAX_BYTES].decode("utf-8", errors="ignore")
+    return {"text": text, "truncated": truncated, "line_count": min(len(lines), SITE_SOURCE_DIFF_MAX_LINES)}
+
+
+def site_source_read(project: Path, path: str) -> dict[str, Any]:
+    project = project_path(project)
+    relative = _site_source_relative(path)
+    root_fd = _open_project_root(project)
+    try:
+        content, _ = _read_source_from_root(root_fd, relative)
+    finally:
+        os.close(root_fd)
+    text = _decode_site_source(relative, content)
+    return {
+        "ok": True,
+        "project": str(project),
+        "path": relative.as_posix(),
+        "size": len(content),
+        "sha256": _source_hash(content),
+        "content": text,
+    }
+
+
+def _write_all(file_fd: int, content: bytes) -> None:
+    remaining = memoryview(content)
+    while remaining:
+        written = os.write(file_fd, remaining)
+        if written == 0:
+            raise OSError("Could not finish writing the file.")
+        remaining = remaining[written:]
+
+
+def _path_identity(metadata: os.stat_result) -> tuple[int, int]:
+    return metadata.st_dev, metadata.st_ino
+
+
+def _unlink_if_identity(parent_fd: int, name: str, identity: tuple[int, int]) -> bool:
+    try:
+        metadata = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return False
+    if _path_identity(metadata) != identity:
+        return False
+    os.unlink(name, dir_fd=parent_fd)
+    return True
+
+
+def _restore_private_backup(parent_fd: int, name: str, backup: str, installed_identity: tuple[int, int] | None) -> None:
+    if installed_identity is not None:
+        _unlink_if_identity(parent_fd, name, installed_identity)
+    try:
+        os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        os.rename(backup, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        return
+    raise RuntimeError(f"Could not restore {name}; a different path appeared during rollback. Original data remains at {backup}.")
+
+
+def _atomic_site_source_write(
+    root_fd: int,
+    relative: Path,
+    content: bytes,
+    *,
+    create_only: bool,
+    expected_sha256: str,
+) -> None:
+    parent_fd = _open_scaffold_directory(root_fd, relative.parent, create=True)
+    temporary = f".unaltraweb-source-{os.getpid()}-{time.time_ns()}"
+    backup = f".unaltraweb-source-backup-{os.getpid()}-{time.time_ns()}"
+    temp_fd: int | None = None
+    backup_present = False
+    installed_identity: tuple[int, int] | None = None
+    try:
+        fcntl.flock(parent_fd, fcntl.LOCK_EX)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        temp_fd = os.open(temporary, flags, 0o644, dir_fd=parent_fd)
+        _write_all(temp_fd, content)
+        os.fsync(temp_fd)
+
+        if create_only:
+            try:
+                os.link(temporary, relative.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd, follow_symlinks=False)
+            except FileExistsError as exc:
+                raise RuntimeError(f"Source path appeared while the create was being applied: {relative}") from exc
+        else:
+            current, metadata = _read_source_at(parent_fd, relative.name)
+            if _source_hash(current) != expected_sha256:
+                raise RuntimeError(f"Source changed after preflight; expected SHA-256 no longer matches: {relative}")
+            current_metadata = os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False)
+            if _path_identity(metadata) != _path_identity(current_metadata):
+                raise RuntimeError(f"Source path changed during the race-safe recheck: {relative}")
+            os.fchmod(temp_fd, stat.S_IMODE(metadata.st_mode))
+            os.rename(relative.name, backup, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            backup_present = True
+            moved, moved_metadata = _read_source_at(parent_fd, backup)
+            if _source_hash(moved) != expected_sha256 or _path_identity(moved_metadata) != _path_identity(metadata):
+                _restore_private_backup(parent_fd, relative.name, backup, None)
+                backup_present = False
+                raise RuntimeError(f"Source changed in the final update window: {relative}")
+            try:
+                os.link(temporary, relative.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd, follow_symlinks=False)
+            except FileExistsError as exc:
+                _restore_private_backup(parent_fd, relative.name, backup, None)
+                backup_present = False
+                raise RuntimeError(f"Source path appeared in the final update window: {relative}") from exc
+            installed_identity = _path_identity(os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False))
+            after, after_metadata = _read_source_at(parent_fd, backup)
+            if _source_hash(after) != expected_sha256 or _path_identity(after_metadata) != _path_identity(metadata):
+                _restore_private_backup(parent_fd, relative.name, backup, installed_identity)
+                backup_present = False
+                installed_identity = None
+                raise RuntimeError(f"Source changed in the final update window: {relative}")
+            os.unlink(backup, dir_fd=parent_fd)
+            backup_present = False
+        if temporary:
+            os.unlink(temporary, dir_fd=parent_fd)
+            temporary = ""
+        os.fsync(parent_fd)
+    finally:
+        if backup_present:
+            try:
+                _restore_private_backup(parent_fd, relative.name, backup, installed_identity)
+            except (OSError, RuntimeError):
+                pass
+        if temp_fd is not None:
+            os.close(temp_fd)
+        if temporary:
+            try:
+                os.unlink(temporary, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+        fcntl.flock(parent_fd, fcntl.LOCK_UN)
+        os.close(parent_fd)
+
+
+def site_source_write(
+    project: Path,
+    path: str,
+    content: str,
+    *,
+    expected_sha256: str = "",
+    create_only: bool = False,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    project = project_path(project)
+    relative = _site_source_relative(path)
+    proposed = content.encode("utf-8")
+    proposed_text = _decode_site_source(relative, proposed)
+
+    root_fd = _open_project_root(project)
+    current = b""
+    exists = True
+    try:
+        try:
+            current, _ = _read_source_from_root(root_fd, relative)
+        except RuntimeError as exc:
+            if isinstance(exc.__cause__, FileNotFoundError):
+                exists = False
+            else:
+                raise
+
+        if exists:
+            if create_only:
+                raise RuntimeError("create_only writes require the source path not to exist.")
+            expected = _expected_source_hash(expected_sha256)
+            actual = _source_hash(current)
+            if expected != actual:
+                raise RuntimeError(f"Source SHA-256 mismatch for {relative}; read the current source before retrying.")
+            current_text = _decode_site_source(relative, current)
+        else:
+            if not create_only:
+                raise RuntimeError("New source files require create_only=True.")
+            if expected_sha256:
+                raise ValueError("New create_only writes must not provide expected_sha256.")
+            expected = ""
+            current_text = ""
+
+        diff = _bounded_source_diff(relative, current_text, proposed_text)
+        if not dry_run:
+            _atomic_site_source_write(
+                root_fd,
+                relative,
+                proposed,
+                create_only=create_only,
+                expected_sha256=expected,
+            )
+    finally:
+        os.close(root_fd)
+
+    return {
+        "ok": True,
+        "operation": "create" if create_only else "update",
+        "dry_run": dry_run,
+        "project": str(project),
+        "path": relative.as_posix(),
+        "previous_sha256": _source_hash(current) if exists else "",
+        "sha256": _source_hash(proposed),
+        "size": len(proposed),
+        "diff": diff,
+    }
+
+
+def site_source_delete(
+    project: Path,
+    path: str,
+    *,
+    expected_sha256: str,
+    dry_run: bool = True,
+    confirm_delete: bool = False,
+) -> dict[str, Any]:
+    project = project_path(project)
+    relative = _site_source_relative(path)
+    if relative == Path("_config.yml"):
+        raise ValueError("_config.yml can never be deleted through site_source_delete.")
+    expected = _expected_source_hash(expected_sha256)
+    root_fd = _open_project_root(project)
+    parent_fd: int | None = None
+    try:
+        parent_fd = _open_scaffold_directory(root_fd, relative.parent, create=False)
+        fcntl.flock(parent_fd, fcntl.LOCK_EX)
+        current, metadata = _read_source_at(parent_fd, relative.name)
+        actual = _source_hash(current)
+        if actual != expected:
+            raise RuntimeError(f"Source SHA-256 mismatch for {relative}; read the current source before retrying.")
+        if not dry_run:
+            if not confirm_delete:
+                raise RuntimeError("A real source deletion requires confirm_delete=True after reviewing the dry-run.")
+            rechecked, rechecked_metadata = _read_source_at(parent_fd, relative.name)
+            path_metadata = os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False)
+            identity = _path_identity(metadata)
+            if _source_hash(rechecked) != expected or identity != _path_identity(rechecked_metadata) or identity != _path_identity(path_metadata):
+                raise RuntimeError(f"Source changed during the race-safe delete recheck: {relative}")
+            tombstone = f".unaltraweb-source-delete-{os.getpid()}-{time.time_ns()}"
+            audit = f"{tombstone}-audit"
+            os.rename(relative.name, tombstone, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            try:
+                moved, moved_metadata = _read_source_at(parent_fd, tombstone)
+                if _source_hash(moved) != expected or _path_identity(moved_metadata) != identity:
+                    os.rename(tombstone, relative.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+                    raise RuntimeError(f"Source changed in the final delete window: {relative}")
+                os.link(tombstone, audit, src_dir_fd=parent_fd, dst_dir_fd=parent_fd, follow_symlinks=False)
+                os.unlink(tombstone, dir_fd=parent_fd)
+                after, after_metadata = _read_source_at(parent_fd, audit)
+                if _source_hash(after) != expected or _path_identity(after_metadata) != identity:
+                    os.rename(audit, relative.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+                    raise RuntimeError(f"Source changed in the final delete window: {relative}")
+                os.unlink(audit, dir_fd=parent_fd)
+            except Exception:
+                for private in [tombstone, audit]:
+                    try:
+                        os.stat(private, dir_fd=parent_fd, follow_symlinks=False)
+                    except FileNotFoundError:
+                        continue
+                    try:
+                        target_metadata = os.stat(relative.name, dir_fd=parent_fd, follow_symlinks=False)
+                    except FileNotFoundError:
+                        os.rename(private, relative.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+                    else:
+                        private_metadata = os.stat(private, dir_fd=parent_fd, follow_symlinks=False)
+                        if _path_identity(target_metadata) == _path_identity(private_metadata):
+                            os.unlink(private, dir_fd=parent_fd)
+                raise
+            os.fsync(parent_fd)
+    except OSError as exc:
+        raise RuntimeError(f"Could not delete source path safely: {relative}: {exc}") from exc
+    finally:
+        if parent_fd is not None:
+            fcntl.flock(parent_fd, fcntl.LOCK_UN)
+            os.close(parent_fd)
+        os.close(root_fd)
+    return {
+        "ok": True,
+        "operation": "delete",
+        "dry_run": dry_run,
+        "project": str(project),
+        "path": relative.as_posix(),
+        "sha256": expected,
+        "size": len(current),
+    }
+
+
 def _bib_key(bibtex: str) -> str:
     match = BIB_ENTRY_RE.search(bibtex.strip())
     if not match:
@@ -2411,16 +3377,237 @@ def build_health(project: Path) -> dict[str, Any]:
     }
 
 
-def run_make(project: Path, target: str, *, extra_args: list[str] | None = None, env: dict[str, str] | None = None) -> dict[str, Any]:
+class _AuditHTMLParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.ids: list[str] = []
+        self.references: list[tuple[str, str, str]] = []
+        self.images_without_alt: list[str] = []
+        self.html_lang = ""
+        self.saw_html = False
+        self.in_title = False
+        self.title_parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = {name.lower(): value for name, value in attrs}
+        tag = tag.lower()
+        identifier = values.get("id")
+        if identifier:
+            self.ids.append(identifier)
+        if tag == "html":
+            self.saw_html = True
+            self.html_lang = str(values.get("lang") or "").strip()
+        if tag == "title":
+            self.in_title = True
+        if tag == "img" and "alt" not in values:
+            self.images_without_alt.append(str(values.get("src") or ""))
+        srcset = str(values.get("srcset") or "").strip()
+        if tag in {"img", "source"} and srcset and not srcset.lower().startswith("data:"):
+            for candidate in srcset.split(","):
+                url = candidate.strip().split(None, 1)[0] if candidate.strip() else ""
+                if url:
+                    self.references.append((tag, "srcset", url))
+        for attribute in ["href", "src", "data"]:
+            value = values.get(attribute)
+            if value and (
+                attribute == "href" and tag in {"a", "area", "link"}
+                or attribute == "src" and tag in {"audio", "embed", "iframe", "img", "script", "source", "track", "video"}
+                or attribute == "data" and tag == "object"
+            ):
+                self.references.append((tag, attribute, value.strip()))
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.handle_starttag(tag, attrs)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "title":
+            self.in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self.in_title:
+            self.title_parts.append(data)
+
+
+def _html_route(relative: Path) -> str:
+    path = relative.as_posix()
+    if path == "index.html":
+        return "/"
+    if path.endswith("/index.html"):
+        return "/" + path[: -len("index.html")]
+    return "/" + path
+
+
+def _internal_html_target(site: Path, source: Path, raw_url: str, baseurl: str) -> tuple[Path | None, str, str]:
+    try:
+        parsed = urllib.parse.urlsplit(raw_url)
+    except ValueError:
+        return None, "missing", ""
+    if parsed.scheme or parsed.netloc or raw_url.startswith("//"):
+        return None, "external", ""
+    if parsed.path.startswith("data:") or parsed.path.startswith("mailto:") or parsed.path.startswith("tel:") or parsed.path.startswith("javascript:"):
+        return None, "external", ""
+
+    source_route = _html_route(source.relative_to(site))
+    joined = urllib.parse.urljoin(source_route, parsed.path) if parsed.path else source_route
+    decoded = urllib.parse.unquote(joined)
+    if "\\" in decoded or any(part == ".." for part in decoded.split("/")):
+        return None, "missing", urllib.parse.unquote(parsed.fragment)
+    prefix = "/" + baseurl.strip("/") if baseurl.strip("/") else ""
+    if prefix and (decoded == prefix or decoded.startswith(prefix + "/")):
+        decoded = decoded[len(prefix):] or "/"
+    relative_url = decoded.lstrip("/")
+    candidates: list[Path]
+    if not relative_url or decoded.endswith("/"):
+        candidates = [site / relative_url / "index.html"]
+    else:
+        target = site / relative_url
+        candidates = [target, Path(str(target) + ".html"), target / "index.html"]
+    for candidate in candidates:
+        try:
+            candidate.relative_to(site)
+        except ValueError:
+            continue
+        if candidate.is_file() and not candidate.is_symlink():
+            return candidate, "internal", urllib.parse.unquote(parsed.fragment)
+    return candidates[0] if candidates else None, "missing", urllib.parse.unquote(parsed.fragment)
+
+
+def html_audit(project: Path) -> dict[str, Any]:
+    project = project_path(project)
+    site = project / "_site"
+    config = site_config(project)
+    baseurl = str(config.get("baseurl") or "")
+    html_files = sorted(path for path in site.rglob("*.html") if path.is_file()) if site.is_dir() else []
+    parsed_files: dict[Path, tuple[str, _AuditHTMLParser]] = {}
+    findings: list[dict[str, Any]] = []
+    external: dict[str, set[str]] = {}
+
+    if not site.is_dir():
+        findings.append({"code": "UW-HTML-SITE-MISSING", "path": "_site", "message": "Generated _site directory does not exist."})
+    elif not html_files:
+        findings.append({"code": "UW-HTML-NO-DOCUMENTS", "path": "_site", "message": "Generated _site contains no HTML documents."})
+
+    for path in html_files:
+        relative = rel(project, path)
+        if path.is_symlink():
+            findings.append({"code": "UW-HTML-UNSAFE-PATH", "path": relative, "message": "Generated HTML is a symlink."})
+            continue
+        try:
+            text = _read_regular_path(
+                path,
+                max_bytes=HTML_AUDIT_FILE_MAX_BYTES,
+                description=f"HTML document {relative}",
+            ).decode("utf-8")
+        except (OSError, UnicodeDecodeError, ValueError) as exc:
+            findings.append({"code": "UW-HTML-READ", "path": relative, "message": str(exc)})
+            continue
+        parser = _AuditHTMLParser()
+        try:
+            parser.feed(text)
+            parser.close()
+        except Exception as exc:
+            findings.append({"code": "UW-HTML-PARSE", "path": relative, "message": str(exc)})
+        parsed_files[path] = (text, parser)
+
+        duplicates = sorted(identifier for identifier in set(parser.ids) if parser.ids.count(identifier) > 1)
+        for identifier in duplicates:
+            findings.append({"code": "UW-HTML-DUPLICATE-ID", "path": relative, "fragment": identifier, "message": "Duplicate id in one document."})
+        if re.search(r"{{.*?}}|{%.*?%}", text, flags=re.DOTALL):
+            findings.append({"code": "UW-HTML-UNRESOLVED-LIQUID", "path": relative, "message": "Unresolved Liquid markup remains in generated HTML."})
+        for source in parser.images_without_alt:
+            findings.append({"code": "UW-HTML-IMG-ALT", "path": relative, "target": source, "message": "img element has no alt attribute."})
+        if not "".join(parser.title_parts).strip():
+            findings.append({"code": "UW-HTML-TITLE", "path": relative, "message": "Document has no non-empty title."})
+        if not parser.saw_html or not parser.html_lang:
+            findings.append({"code": "UW-HTML-LANG", "path": relative, "message": "html element has no non-empty lang attribute."})
+
+    id_index = {path: set(parser.ids) for path, (_, parser) in parsed_files.items()}
+    for source, (_, parser) in parsed_files.items():
+        source_relative = rel(project, source)
+        for tag, attribute, raw_url in parser.references:
+            target, kind, fragment = _internal_html_target(site, source, raw_url, baseurl)
+            if kind == "external":
+                external.setdefault(raw_url, set()).add(source_relative)
+                continue
+            if kind == "missing" or target is None:
+                findings.append({
+                    "code": "UW-HTML-INTERNAL-TARGET",
+                    "path": source_relative,
+                    "target": raw_url,
+                    "element": f"{tag}[{attribute}]",
+                    "message": "Internal link or asset target does not exist.",
+                })
+                continue
+            if fragment and target.suffix.lower() == ".html" and fragment not in id_index.get(target, set()):
+                findings.append({
+                    "code": "UW-HTML-FRAGMENT",
+                    "path": source_relative,
+                    "target": raw_url,
+                    "fragment": fragment,
+                    "message": "Internal fragment does not match an id in the target document.",
+                })
+
+    by_code: dict[str, int] = {}
+    for finding in findings:
+        by_code[finding["code"]] = by_code.get(finding["code"], 0) + 1
+    return {
+        "ok": not findings,
+        "project": str(project),
+        "site": str(site),
+        "html_files": len(html_files),
+        "finding_count": len(findings),
+        "findings_by_code": dict(sorted(by_code.items())),
+        "findings": findings,
+        "external_link_count": len(external),
+        "external_links": [
+            {"url": url, "sources": sorted(sources)} for url, sources in sorted(external.items())
+        ],
+        "external_fetches": 0,
+    }
+
+
+def _process_payload(completed: Any) -> dict[str, Any]:
+    return {
+        "returncode": completed.returncode,
+        "ok": completed.returncode == 0,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "timed_out": bool(getattr(completed, "timed_out", False)),
+        "stdout_truncated": bool(getattr(completed, "stdout_truncated", False)),
+        "stderr_truncated": bool(getattr(completed, "stderr_truncated", False)),
+    }
+
+
+def run_make(
+    project: Path,
+    target: str,
+    *,
+    extra_args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+    timeout_seconds: float | None = None,
+) -> dict[str, Any]:
     merged_env = os.environ.copy()
     if env:
         merged_env.update(env)
     command = ["make", target, *(extra_args or [])]
-    completed = subprocess.run(command, cwd=str(project), env=merged_env, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
-    return {"target": target, "command": command, "returncode": completed.returncode, "ok": completed.returncode == 0, "stdout": completed.stdout, "stderr": completed.stderr}
+    completed = run_process(
+        command,
+        cwd=project,
+        env=merged_env,
+        timeout_seconds=timeout_seconds or MAKE_TIMEOUTS.get(target, DEFAULT_MAKE_TIMEOUT),
+    )
+    return {"target": target, "command": command, **_process_payload(completed)}
 
 
-def run_factory_make(factory: Path, project: Path, target: str, *, extra_args: list[str] | None = None, env: dict[str, str] | None = None) -> dict[str, Any]:
+def run_factory_make(
+    factory: Path,
+    project: Path,
+    target: str,
+    *,
+    extra_args: list[str] | None = None,
+    env: dict[str, str] | None = None,
+    timeout_seconds: float | None = None,
+) -> dict[str, Any]:
     factory_root = project_path(factory)
     project_root = project_path(project)
     unsafe = set("$`\"'\\\r\n")
@@ -2430,24 +3617,90 @@ def run_factory_make(factory: Path, project: Path, target: str, *, extra_args: l
     merged_env = os.environ.copy()
     if env:
         merged_env.update(env)
-    completed = subprocess.run(command, env=merged_env, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    worker_role = WORKER_TARGET_ROLES.get(target, "")
+    worker_context: dict[str, str] = {}
+    if worker_role:
+        host_project = os.environ.get("UNALTRAWEB_DOCKER_ROOT", "").strip() or str(project_root)
+        project_id = hashlib.sha256(host_project.encode("utf-8")).hexdigest()[:16]
+        token = hashlib.sha256(f"{project_id}:{target}:{time.time_ns()}".encode("utf-8")).hexdigest()[:16]
+        worker_context = {"role": worker_role, "project_id": project_id, "token": token}
+        merged_env.update({
+            "UNALTRAWEB_WORKER_ROLE": worker_role,
+            "UNALTRAWEB_WORKER_PROJECT": project_id,
+            "UNALTRAWEB_WORKER_TOKEN": token,
+        })
+    completed = run_process(
+        command,
+        env=merged_env,
+        timeout_seconds=timeout_seconds or MAKE_TIMEOUTS.get(target, DEFAULT_MAKE_TIMEOUT),
+    )
     payload: dict[str, Any] = {
         "target": target,
         "command": command,
-        "returncode": completed.returncode,
-        "ok": completed.returncode == 0,
-        "stdout": completed.stdout,
-        "stderr": completed.stderr,
+        **_process_payload(completed),
     }
-    if completed.stdout.strip():
+    worker_cleanup = _cleanup_timed_out_workers(**worker_context) if bool(getattr(completed, "timed_out", False)) and worker_context else None
+    parse_error = ""
+    parsed: Any = None
+    if bool(getattr(completed, "stdout_truncated", False)):
+        parse_error = "Factory JSON output was truncated."
+    elif not completed.stdout.strip():
+        parse_error = "Factory command returned no JSON output."
+    else:
         try:
-            parsed = json.loads(completed.stdout)
-        except json.JSONDecodeError:
-            pass
-        else:
-            if isinstance(parsed, dict):
-                payload = {**parsed, "target": target, "command": command, "returncode": completed.returncode, "ok": completed.returncode == 0 and bool(parsed.get("ok", True)), "stderr": completed.stderr}
+            parsed = _strict_json_loads(completed.stdout)
+        except (json.JSONDecodeError, ValueError) as exc:
+            parse_error = f"Factory command returned invalid JSON: {exc}"
+        if not parse_error and not isinstance(parsed, dict):
+            parse_error = "Factory command JSON output must be an object."
+    if parse_error:
+        payload = {**payload, "ok": False, "output_error": parse_error}
+    else:
+        payload = {
+            **parsed,
+            "target": target,
+            "command": command,
+            **_process_payload(completed),
+            "ok": completed.returncode == 0 and bool(parsed.get("ok", True)),
+        }
+    if worker_cleanup is not None:
+        payload["worker_cleanup"] = worker_cleanup
     return payload
+
+
+def _cleanup_timed_out_workers(*, role: str, project_id: str, token: str) -> dict[str, Any]:
+    filters = [
+        f"label={WORKER_FACTORY_LABEL}=unaltraweb",
+        f"label={WORKER_ROLE_LABEL}={role}",
+        f"label={WORKER_PROJECT_LABEL}={project_id}",
+        f"label={WORKER_TOKEN_LABEL}={token}",
+    ]
+    command = ["docker", "ps", "-aq"]
+    for value in filters:
+        command.extend(["--filter", value])
+    try:
+        listed = run_process(command, timeout_seconds=10)
+    except OSError as exc:
+        return {"ok": False, "filters": filters, "removed": [], "error": str(exc)}
+    if listed.returncode != 0 or listed.stdout_truncated:
+        return {
+            "ok": False,
+            "filters": filters,
+            "removed": [],
+            "error": listed.stderr.strip() or "Docker worker inventory failed or was truncated.",
+        }
+    container_ids = [line.strip() for line in listed.stdout.splitlines() if line.strip()]
+    if any(not re.fullmatch(r"[0-9a-f]{12,64}", container_id) for container_id in container_ids):
+        return {"ok": False, "filters": filters, "removed": [], "error": "Docker returned an invalid worker container id."}
+    if not container_ids:
+        return {"ok": True, "filters": filters, "removed": []}
+    removed = run_process(["docker", "rm", "-f", *container_ids], timeout_seconds=30)
+    return {
+        "ok": removed.returncode == 0,
+        "filters": filters,
+        "removed": container_ids if removed.returncode == 0 else [],
+        "error": "" if removed.returncode == 0 else (removed.stderr.strip() or "Docker worker cleanup failed."),
+    }
 
 
 def _computation_env(source: str = "", stale_only: bool = False) -> dict[str, str]:
@@ -2506,20 +3759,305 @@ def web_capture_render(project: Path, factory: Path, source: str = "", *, confir
     return _web_capture_render_isolated(project, factory, env)
 
 
+def _companion_input_paths(project: Path, owner: str) -> list[Path]:
+    if owner == "vegavisuals":
+        paths = [project / ".vegavisuals.yml"] if (project / ".vegavisuals.yml").is_file() else []
+        if paths:
+            manifest = _vegavisuals_manifest(project)
+            for index, visualization in enumerate(manifest["visualizations"]):
+                if not isinstance(visualization, dict):
+                    raise ValueError(f"vegavisuals manifest visualizations[{index}] must be a mapping.")
+                paths.append(
+                    _companion_dependency_path(
+                        project,
+                        visualization.get("source"),
+                        f"vegavisuals manifest visualizations[{index}].source",
+                    )
+                )
+        if (project / "assets").is_dir():
+            paths.extend(
+                path for path in (project / "assets").rglob("*")
+                if path.is_file() and path.name.lower().endswith(VEGA_SOURCE_SUFFIXES)
+            )
+        return sorted(set(paths))
+    return sorted({
+        path
+        for root_name in ["assets", "_chapters", "_documentation"]
+        for path in (project / root_name).rglob("*")
+        if (project / root_name).is_dir() and path.is_file() and path.suffix.lower() in DIAGRAM_SOURCE_SUFFIXES
+    })
+
+
+def _vegavisuals_manifest(project: Path) -> dict[str, Any]:
+    path = project / ".vegavisuals.yml"
+    try:
+        value = load_yaml_text(_companion_file_bytes(project, path).decode("utf-8"))
+    except Exception as exc:
+        raise ValueError(f"Invalid vegavisuals manifest: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError("The vegavisuals manifest must be a YAML mapping.")
+    visualizations = value.get("visualizations")
+    if not isinstance(visualizations, list):
+        raise ValueError("The vegavisuals manifest must contain a visualizations array.")
+    return value
+
+
+def _companion_dependency_path(project: Path, raw: Any, context: str) -> Path:
+    if not isinstance(raw, str) or not raw.strip() or raw != raw.strip():
+        raise ValueError(f"{context} must be a non-empty project-relative string.")
+    parsed = urllib.parse.urlsplit(raw)
+    if parsed.scheme or parsed.netloc or parsed.query or parsed.fragment or any(char in raw for char in "${}"):
+        raise ValueError(f"{context} is remote or dynamic and cannot be verified as a static project input: {raw}")
+    decoded = urllib.parse.unquote(parsed.path)
+    relative = Path(decoded)
+    if "\\" in decoded or relative.is_absolute() or any(part in {"", ".", ".."} for part in relative.parts):
+        raise ValueError(f"{context} must be a confined project-relative path: {raw}")
+    return project / relative
+
+
+def _vega_data_urls(project: Path, source: Path) -> list[Path]:
+    try:
+        value = _strict_json_loads(_companion_file_bytes(project, source).decode("utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError, RuntimeError, json.JSONDecodeError, RecursionError) as exc:
+        raise ValueError(f"Invalid Vega/Vega-Lite source {rel(project, source)}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"Vega/Vega-Lite source must contain a JSON object: {rel(project, source)}")
+
+    paths: list[Path] = []
+    nodes = 0
+    stack: list[tuple[Any, int, bool]] = [(value, 0, False)]
+    while stack:
+        node, depth, data_context = stack.pop()
+        nodes += 1
+        if nodes > COMPANION_JSON_MAX_NODES:
+            raise ValueError(f"Vega/Vega-Lite source exceeds the {COMPANION_JSON_MAX_NODES}-node inspection limit: {rel(project, source)}")
+        if depth > COMPANION_JSON_MAX_DEPTH:
+            raise ValueError(f"Vega/Vega-Lite source exceeds the {COMPANION_JSON_MAX_DEPTH}-level inspection limit: {rel(project, source)}")
+        if isinstance(node, dict):
+            if data_context and "url" in node:
+                paths.append(_companion_dependency_path(project, node["url"], f"data.url in {rel(project, source)}"))
+            for key, child in node.items():
+                stack.append((child, depth + 1, key == "data"))
+        elif isinstance(node, list):
+            for child in node:
+                stack.append((child, depth + 1, data_context))
+    return paths
+
+
+def _companion_expected_inputs(project: Path, owner: str, sources: list[Path]) -> list[Path]:
+    if owner == "diavisuals":
+        return []
+    if owner != "vegavisuals":
+        raise ValueError(f"Unknown companion provider: {owner}")
+
+    manifest = _vegavisuals_manifest(project)
+    dependencies: list[Path] = []
+
+    def add_explicit(value: dict[str, Any], context: str) -> None:
+        if "inputs" not in value:
+            return
+        inputs = value["inputs"]
+        if not isinstance(inputs, list):
+            raise ValueError(f"{context} inputs must be an array of project-relative paths.")
+        for index, raw in enumerate(inputs):
+            dependencies.append(_companion_dependency_path(project, raw, f"{context} inputs[{index}]"))
+
+    add_explicit(manifest, "vegavisuals manifest")
+    for index, visualization in enumerate(manifest["visualizations"]):
+        if not isinstance(visualization, dict):
+            raise ValueError(f"vegavisuals manifest visualizations[{index}] must be a mapping.")
+        add_explicit(visualization, f"vegavisuals manifest visualizations[{index}]")
+    for source in sources:
+        if source.name.lower().endswith(VEGA_SOURCE_SUFFIXES):
+            dependencies.extend(_vega_data_urls(project, source))
+    return sorted(set(dependencies))
+
+
+def _companion_expected_outputs(project: Path, owner: str, inputs: list[Path]) -> list[Path]:
+    if owner == "diavisuals":
+        outputs: list[Path] = []
+        for source in inputs:
+            edited = Path(str(source) + ".edited.svg")
+            generated = Path(str(source) + ".svg")
+            outputs.append(edited if edited.is_file() else generated)
+        return outputs
+    manifest = _vegavisuals_manifest(project)
+    visualizations = manifest["visualizations"]
+    outputs = []
+    for item in visualizations or []:
+        if not isinstance(item, dict) or not str(item.get("output") or "").strip():
+            continue
+        relative = Path(str(item["output"]))
+        if relative.is_absolute() or ".." in relative.parts:
+            outputs.append(project / relative)
+            continue
+        outputs.append(project / relative)
+    return sorted(set(outputs))
+
+
+def _companion_file_bytes(project: Path, path: Path) -> bytes:
+    try:
+        relative = path.relative_to(project)
+    except ValueError as exc:
+        raise ValueError(f"Companion path escapes the project: {path}") from exc
+    root_fd = _open_project_root(project)
+    try:
+        parent_fd = _open_scaffold_directory(root_fd, relative.parent, create=False)
+        try:
+            content, _ = _read_regular_at(
+                parent_fd,
+                relative.name,
+                max_bytes=COMPANION_FILE_MAX_BYTES,
+                description=f"Companion file {relative}",
+            )
+            return content
+        finally:
+            os.close(parent_fd)
+    finally:
+        os.close(root_fd)
+
+
+def _companion_request_sha256(project: Path, owner: str, inputs: list[Path]) -> str:
+    digest = hashlib.sha256()
+    digest.update(f"unaltraweb-companion-receipt-v1\0{owner}\0".encode("utf-8"))
+    for path in sorted(set(inputs)):
+        relative = path.relative_to(project).as_posix().encode("utf-8")
+        content = _companion_file_bytes(project, path)
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(len(content).to_bytes(8, "big"))
+        digest.update(content)
+    return digest.hexdigest()
+
+
+def _companion_receipt_status(project: Path, owner: str, inputs: list[Path] | None = None) -> dict[str, Any]:
+    receipt_path = project / ".unaltraweb/receipts" / f"{owner}.json"
+    base = {
+        "provider": owner,
+        "receipt": rel(project, receipt_path),
+        "request_sha256": "",
+        "expected_inputs": [],
+        "expected_outputs": [],
+    }
+    try:
+        if inputs is None:
+            inputs = _companion_input_paths(project, owner)
+        expected_inputs = _companion_expected_inputs(project, owner, inputs)
+        expected_outputs = _companion_expected_outputs(project, owner, inputs)
+        base["expected_inputs"] = [rel(project, path) for path in expected_inputs]
+        base["expected_outputs"] = [rel(project, path) for path in expected_outputs]
+        for path in expected_inputs:
+            _companion_file_bytes(project, path)
+        base["request_sha256"] = _companion_request_sha256(project, owner, inputs)
+    except (OSError, ValueError, RuntimeError) as exc:
+        return {**base, "ok": False, "state": "invalid", "error": str(exc)}
+    if not receipt_path.is_file() or receipt_path.is_symlink():
+        return {**base, "ok": False, "state": "missing", "error": "Provider receipt is missing."}
+    try:
+        value = _strict_json_loads(_companion_file_bytes(project, receipt_path).decode("utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        return {**base, "ok": False, "state": "invalid", "error": str(exc)}
+    selected = component(owner)
+    expected_metadata = {
+        "schema_version": 1,
+        "provider": owner,
+        "provider_version": selected["version"],
+        "release": selected["release"],
+        "request_sha256": base["request_sha256"],
+        "ok": True,
+    }
+    expected_keys = {*expected_metadata, "inputs", "artifacts"}
+    metadata_types_ok = (
+        isinstance(value, dict)
+        and type(value.get("schema_version")) is int
+        and all(isinstance(value.get(key), str) for key in ["provider", "provider_version", "release", "request_sha256"])
+        and value.get("ok") is True
+    )
+    if not metadata_types_ok or set(value) != expected_keys or any(value.get(key) != expected for key, expected in expected_metadata.items()):
+        return {**base, "ok": False, "state": "mismatch", "error": "Provider receipt metadata does not match the current request and component contract."}
+    artifacts = value.get("artifacts")
+    receipt_inputs = value.get("inputs")
+    if not isinstance(receipt_inputs, list) or len(receipt_inputs) > 500 or not isinstance(artifacts, list) or len(artifacts) > 500:
+        return {**base, "ok": False, "state": "invalid", "error": "Provider receipt inputs and artifacts must be bounded arrays."}
+
+    def receipt_files(items: list[Any], label: str) -> dict[str, str]:
+        received: dict[str, str] = {}
+        for item in items:
+            if not isinstance(item, dict) or set(item) != {"path", "sha256"}:
+                raise ValueError(f"Provider receipt {label} entries require only path and sha256.")
+            relative = Path(str(item["path"]))
+            sha256 = str(item["sha256"])
+            if relative.is_absolute() or any(part in {"", ".", ".."} for part in relative.parts) or not re.fullmatch(r"[0-9a-f]{64}", sha256):
+                raise ValueError(f"Invalid provider receipt {label}: {relative}")
+            if relative.as_posix() in received:
+                raise ValueError(f"Duplicate provider receipt {label}: {relative}")
+            received[relative.as_posix()] = sha256
+        return received
+
+    try:
+        verified_inputs = receipt_files(receipt_inputs, "input")
+        received = receipt_files(artifacts, "artifact")
+    except ValueError as exc:
+        return {**base, "ok": False, "state": "invalid", "error": str(exc)}
+    expected_input_names = {rel(project, path) for path in expected_inputs}
+    if set(verified_inputs) != expected_input_names:
+        return {**base, "ok": False, "state": "mismatch", "error": "Provider receipt input inventory does not match current explicit and discovered dependencies."}
+    expected_names = {rel(project, path) for path in expected_outputs}
+    if set(received) != expected_names:
+        return {**base, "ok": False, "state": "mismatch", "error": "Provider receipt artifact inventory does not match current declared outputs."}
+    try:
+        for label, entries in [("input", verified_inputs), ("artifact", received)]:
+            for name, sha256 in entries.items():
+                actual = _source_hash(_companion_file_bytes(project, project / name))
+                if actual != sha256:
+                    raise ValueError(f"Provider receipt {label} hash mismatch: {name}")
+    except (OSError, ValueError, RuntimeError) as exc:
+        return {**base, "ok": False, "state": "invalid", "error": str(exc)}
+    return {**base, "ok": True, "state": "verified", "inputs": verified_inputs, "artifacts": received}
+
+
 def visualization_status(project: Path, factory: Path) -> dict[str, Any]:
+    del factory
     project = project_path(project)
     configured = (project / ".vegavisuals.yml").is_file()
+    receipt = _companion_receipt_status(project, "vegavisuals") if configured else None
     return {
-        "ok": True,
+        "ok": receipt["ok"] if receipt is not None else True,
         "configured": configured,
-        "delegated": configured,
+        "delegated": False,
         "owner": "vegavisuals",
         "required_tool": "visualization_check" if configured else "",
+        "receipt": receipt,
         "message": (
-            "Run visualization_check through the required vegavisuals MCP before building."
+            "Run visualization_check through vegavisuals and retain its verifiable provider receipt before building."
             if configured
             else "No .vegavisuals.yml; no Vega visualization check is required."
         ),
+    }
+
+
+def _diagram_status(project: Path) -> dict[str, Any]:
+    sources = _companion_input_paths(project, "diavisuals")
+    records: list[dict[str, Any]] = []
+    for source in sources:
+        generated = Path(str(source) + ".svg")
+        edited = Path(str(source) + ".edited.svg")
+        selected = edited if edited.is_file() else generated
+        state = "missing" if not selected.is_file() else ("stale" if source.stat().st_mtime_ns > selected.stat().st_mtime_ns else "fresh")
+        records.append({
+            "source": rel(project, source),
+            "output": rel(project, selected),
+            "edited_override": selected == edited,
+            "state": state,
+        })
+    receipt = _companion_receipt_status(project, "diavisuals", sources) if sources else None
+    outputs_fresh = all(record["state"] == "fresh" for record in records)
+    return {
+        "ok": outputs_fresh and (receipt is None or receipt["ok"]),
+        "configured": bool(sources),
+        "owner": "diavisuals",
+        "sources": records,
+        "receipt": receipt,
     }
 
 
@@ -2543,9 +4081,30 @@ def _site_profile_arg(site_profile_value: str) -> list[str]:
 
 def build_site(project: Path, factory: Path, site_profile: str = "") -> dict[str, Any]:
     project, detection = _require_site_runtime(project, "build_native")
+    companion_checks: dict[str, Any] = {}
+    visualization = visualization_status(project, factory)
+    if visualization["configured"]:
+        companion_checks["vegavisuals"] = visualization
+    diagrams = _diagram_status(project)
+    if diagrams["configured"]:
+        companion_checks["diavisuals"] = diagrams
+    blocked = {name: value for name, value in companion_checks.items() if value.get("ok") is not True}
+    if blocked:
+        return {
+            "ok": False,
+            "returncode": 1,
+            "runtime": "mcp-container",
+            "nested_container": False,
+            "site": detection,
+            "companion_checks": companion_checks,
+            "error": "Build blocked until companion outputs are fresh and provider receipts verify current sources, inputs, and outputs.",
+        }
     args = [f"LOCAL_CORE={project_path(factory)}", *_site_profile_arg(site_profile)]
     result = run_make(project, "build-native", extra_args=args, env={"UNALTRAWEB_MCP_RUNTIME": "1"})
-    return {**result, "runtime": "mcp-container", "nested_container": False, "site": detection}
+    if result["ok"]:
+        audit = html_audit(project)
+        result = {**result, "ok": audit["ok"], "html_audit": audit}
+    return {**result, "runtime": "mcp-container", "nested_container": False, "site": detection, "companion_checks": companion_checks}
 
 
 PREVIEW_FACTORY_LABEL = "io.context.mcp-factory"
@@ -2557,9 +4116,11 @@ PREVIEW_BASEURL_LABEL = "io.context.mcp-baseurl"
 PREVIEW_PATH_LABEL = "io.context.mcp-path"
 
 
-def _docker(args: list[str]) -> subprocess.CompletedProcess[str]:
+def _docker(args: list[str]) -> ProcessResult:
+    action = args[0] if args else ""
+    timeout = 30.0 if action in {"run", "rm", "network"} else 10.0
     try:
-        return subprocess.run(["docker", *args], text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+        return run_process(["docker", *args], timeout_seconds=timeout)
     except OSError as exc:
         raise RuntimeError(f"Docker is not available to the MCP runtime: {exc}") from exc
 
@@ -2572,7 +4133,7 @@ def _web_capture_render_isolated(project: Path, factory: Path, env: dict[str, st
     token = hashlib.sha256(f"{host_project}:{time.time_ns()}".encode("utf-8")).hexdigest()[:12]
     network = f"unaltraweb-capture-{token}"
     service = f"unaltraweb-capture-site-{token}"
-    image = os.environ.get("UNALTRAWEB_MCP_IMAGE", "ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0")
+    image = os.environ.get("UNALTRAWEB_MCP_IMAGE", component_reference("mcp"))
     owner = os.environ.get("UNALTRAWEB_PROJECT_USER", f"{os.getuid()}:{os.getgid()}").strip()
     if not re.fullmatch(r"\d+:\d+", owner):
         raise RuntimeError("UNALTRAWEB_PROJECT_USER must use the uid:gid format.")
@@ -2649,9 +4210,11 @@ def _preview_inspect(name: str) -> dict[str, Any] | None:
         if "no such object" in message.lower() or "no such container" in message.lower():
             return None
         raise RuntimeError(message or f"Docker could not inspect {name}")
+    if bool(getattr(completed, "stdout_truncated", False)):
+        raise RuntimeError(f"Docker inspect output was truncated for {name}")
     try:
-        payload = json.loads(completed.stdout)
-    except json.JSONDecodeError as exc:
+        payload = _strict_json_loads(completed.stdout)
+    except (json.JSONDecodeError, ValueError) as exc:
         raise RuntimeError(f"Docker returned invalid inspect data for {name}") from exc
     return payload[0] if isinstance(payload, list) and payload and isinstance(payload[0], dict) else None
 
@@ -2730,9 +4293,12 @@ def _wait_for_preview(project: Path, name: str, timeout_seconds: float) -> tuple
         if not latest["running"]:
             break
         internal_url = str(latest.get("internal_url") or "")
-        if internal_url and http_check(internal_url, timeout_seconds=1.0)["ok"]:
-            ready = True
-            break
+        if internal_url:
+            parsed = urllib.parse.urlsplit(internal_url)
+            origin = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+            if _http_probe(origin, [parsed.path or "/"], timeout_seconds=1.0)["ok"]:
+                ready = True
+                break
         if time.monotonic() >= deadline:
             break
         time.sleep(0.5)
@@ -2776,7 +4342,7 @@ def preview_start(project: Path, *, port: int = 4000, site_profile: str = "", ti
     prefix = "/" + baseurl.strip("/") if baseurl else ""
     lang = default_language(config).strip("/")
     route = f"{prefix}/{lang}/" if lang else f"{prefix}/"
-    image = os.environ.get("UNALTRAWEB_MCP_IMAGE", "ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0")
+    image = os.environ.get("UNALTRAWEB_MCP_IMAGE", component_reference("mcp"))
     owner = os.environ.get("UNALTRAWEB_PROJECT_USER", "").strip()
     if owner and not re.fullmatch(r"\d+:\d+", owner):
         raise RuntimeError("UNALTRAWEB_PROJECT_USER must use the uid:gid format.")
@@ -2878,20 +4444,84 @@ def bibliometrics_update(project: Path, factory: Path, *, fetch_scimago: bool = 
     return run_factory_make(factory, project, target, extra_args=extra)
 
 
-def http_check(base_url: str, paths: list[str] | None = None, timeout_seconds: float = 5.0) -> dict[str, Any]:
-    paths = paths or ["/"]
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _validated_http_paths(paths: list[str], timeout_seconds: float) -> list[str]:
+    if not 0.1 <= timeout_seconds <= 5.0:
+        raise ValueError("HTTP timeout must be between 0.1 and 5 seconds.")
+    if not paths or len(paths) > 20:
+        raise ValueError("HTTP checks require between 1 and 20 paths.")
+    if len(paths) * timeout_seconds > 30:
+        raise ValueError("Combined HTTP path count and timeout exceed the 30-second budget.")
+    validated: list[str] = []
+    for raw in paths:
+        if not isinstance(raw, str) or not raw.startswith("/") or raw.startswith("//"):
+            raise ValueError("HTTP check paths must be absolute local paths beginning with one slash.")
+        if "\\" in raw or any(ord(character) < 32 for character in raw):
+            raise ValueError("HTTP check path contains hostile characters.")
+        parsed = urllib.parse.urlsplit(raw)
+        if parsed.scheme or parsed.netloc or parsed.fragment:
+            raise ValueError("HTTP check paths must not contain an origin or fragment.")
+        decoded = parsed.path
+        for _ in range(3):
+            decoded = urllib.parse.unquote(decoded)
+        if "\\" in decoded or any(ord(character) < 32 for character in decoded) or any(part in {".", ".."} for part in decoded.split("/")):
+            raise ValueError("HTTP check paths must not contain encoded or literal traversal.")
+        validated.append(urllib.parse.urlunsplit(("", "", parsed.path, parsed.query, "")))
+    return validated
+
+
+def _http_probe(origin: str, paths: list[str], *, timeout_seconds: float) -> dict[str, Any]:
+    parsed_origin = urllib.parse.urlsplit(origin)
+    if parsed_origin.scheme != "http" or not parsed_origin.netloc or parsed_origin.path not in {"", "/"} or parsed_origin.query or parsed_origin.fragment or parsed_origin.username or parsed_origin.password:
+        raise ValueError("Private HTTP probe origin must be an exact HTTP origin.")
+    paths = _validated_http_paths(paths, timeout_seconds)
     checks: list[dict[str, Any]] = []
-    parsed_base = base_url.rstrip("/")
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), _NoRedirectHandler())
     for path in paths:
-        url = parsed_base + (path if path.startswith("/") else "/" + path)
+        url = origin.rstrip("/") + path
         try:
-            with urllib.request.urlopen(url, timeout=timeout_seconds) as response:
-                checks.append({"url": url, "ok": 200 <= response.status < 400, "status": response.status, "reason": response.reason})
+            with opener.open(url, timeout=timeout_seconds) as response:
+                body = response.read(HTTP_RESPONSE_MAX_BYTES + 1)
+                checks.append({
+                    "url": url,
+                    "ok": 200 <= response.status < 300,
+                    "status": response.status,
+                    "reason": response.reason,
+                    "response_bytes": min(len(body), HTTP_RESPONSE_MAX_BYTES),
+                    "response_truncated": len(body) > HTTP_RESPONSE_MAX_BYTES,
+                })
         except urllib.error.HTTPError as error:
-            checks.append({"url": url, "ok": False, "status": error.code, "reason": str(error)})
+            reason = "redirect rejected" if 300 <= error.code < 400 else str(error)
+            checks.append({"url": url, "ok": False, "status": error.code, "reason": reason})
         except OSError as error:
             checks.append({"url": url, "ok": False, "status": None, "reason": str(error)})
-    return {"base_url": base_url, "ok": all(item["ok"] for item in checks), "checks": checks}
+    return {"origin": origin, "ok": all(item["ok"] for item in checks), "checks": checks, "redirects_followed": 0}
+
+
+def http_check(project: Path, paths: list[str] | None = None, timeout_seconds: float = 3.0) -> dict[str, Any]:
+    project = project_path(project)
+    supplied_paths = _validated_http_paths(paths, timeout_seconds) if paths is not None else None
+    _, project_id, name = _preview_identity(project)
+    info = _preview_inspect(name)
+    if info is None:
+        raise RuntimeError("No owned preview exists for this project; start preview_start first.")
+    if not _preview_owned(info, project_id):
+        raise RuntimeError(f"Refusing to probe unowned Docker container: {name}")
+    preview = _preview_payload(project, info)
+    if not preview["running"]:
+        raise RuntimeError(f"Owned preview is not running: {name}")
+    internal_url = str(preview.get("internal_url") or "")
+    parsed = urllib.parse.urlsplit(internal_url)
+    if parsed.scheme != "http" or not parsed.netloc:
+        raise RuntimeError("Owned preview has no valid container-internal HTTP origin.")
+    origin = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+    selected_paths = supplied_paths or _validated_http_paths([parsed.path or "/"], timeout_seconds)
+    result = _http_probe(origin, selected_paths, timeout_seconds=timeout_seconds)
+    return {**result, "project": str(project), "container": name, "owned": True}
 
 
 def prompt_text(factory: Path, name: str) -> str:
@@ -2923,6 +4553,247 @@ def prompt_inventory(factory: Path) -> dict[str, Any]:
     }
 
 
+def _site_doctor_finding(code: str, severity: str, expected: Any, actual: Any, remediation: str) -> dict[str, Any]:
+    return {
+        "code": code,
+        "severity": severity,
+        "expected": expected,
+        "actual": actual,
+        "remediation": remediation,
+    }
+
+
+def _strict_site_config(project: Path) -> dict[str, Any]:
+    path = project / "_config.yml"
+    if not path.is_file():
+        raise ValueError("_config.yml is missing.")
+    root_fd = _open_project_root(project)
+    try:
+        content, _ = _read_source_from_root(root_fd, Path("_config.yml"))
+    finally:
+        os.close(root_fd)
+    text = _decode_site_source(Path("_config.yml"), content)
+    value = load_yaml_text(text)
+    if not isinstance(value, dict):
+        raise ValueError("_config.yml must contain a YAML mapping.")
+    return value
+
+
+def _core_override_inventory(project: Path) -> dict[str, Any]:
+    roots = ["_layouts", "_includes", "_plugins", "_sass"]
+    files: list[str] = []
+    symlinks: list[str] = []
+    for root_name in roots:
+        root = project / root_name
+        if root.is_symlink():
+            symlinks.append(rel(project, root))
+            continue
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*")):
+            if path.is_symlink():
+                symlinks.append(rel(project, path))
+            elif path.is_file():
+                files.append(rel(project, path))
+    return {"roots": roots, "count": len(files), "files": files, "symlinks": symlinks}
+
+
+def site_doctor(project: Path, factory: Path | None = None) -> dict[str, Any]:
+    from .distribution import distribution_doctor
+
+    project = project_path(project)
+    factory_root = project_path(factory) if factory is not None else None
+    distribution = distribution_doctor(project=project, factory=factory_root, check_docker=False)
+    findings = list(distribution["findings"])
+    checks: dict[str, Any] = {}
+
+    try:
+        config = _strict_site_config(project)
+    except Exception as exc:
+        # PyYAML parse failures do not share a stable exception base with the fallback parser.
+        config = {}
+        findings.append(_site_doctor_finding(
+            "UW-SITE-CONFIG-PARSE",
+            "error",
+            "strict UTF-8 YAML mapping with unique keys",
+            str(exc),
+            "Fix _config.yml syntax, encoding, root type, and duplicate keys.",
+        ))
+        checks["config"] = {"ok": False, "error": str(exc)}
+    else:
+        findings.append(_site_doctor_finding(
+            "UW-SITE-CONFIG-PARSE",
+            "info",
+            "strict UTF-8 YAML mapping with unique keys",
+            "valid",
+            "No action required.",
+        ))
+        checks["config"] = {"ok": True}
+
+    detection = detect_site(project)
+    profile = site_profile(config)
+    languages = configured_languages(config)
+    language_ok = bool(languages) and all(LANGUAGE_RE.fullmatch(value) for value in languages)
+    profile_ok = profile in PROFILE_CONTRACTS
+    checks["identity"] = {"detection": detection, "profile": profile, "languages": languages, "default_language": default_language(config)}
+    findings.append(_site_doctor_finding(
+        "UW-SITE-DETECTION",
+        "info" if detection["is_unaltraweb_site"] else "error",
+        "unaltraweb consumer site",
+        "detected" if detection["is_unaltraweb_site"] else "not detected",
+        "No action required." if detection["is_unaltraweb_site"] else "Restore the unaltraweb theme/plugin and gem markers.",
+    ))
+    findings.append(_site_doctor_finding(
+        "UW-SITE-PROFILE",
+        "info" if profile_ok else "error",
+        sorted(PROFILE_CONTRACTS),
+        profile or "missing",
+        "No action required." if profile_ok else "Set unaltraweb.site_profile to one supported profile.",
+    ))
+    findings.append(_site_doctor_finding(
+        "UW-SITE-LANGUAGE",
+        "info" if language_ok else "error",
+        "one or more valid configured language identifiers",
+        languages,
+        "No action required." if language_ok else "Set lang/default_lang and languages to valid language identifiers.",
+    ))
+
+    required_targets = ["site-check-native", "build-native", "serve-native", "test-native"]
+    make_contract = {target: _make_target_available(project, target) for target in required_targets}
+    checks["make_contract"] = make_contract
+    missing_targets = [target for target, available in make_contract.items() if not available]
+    findings.append(_site_doctor_finding(
+        "UW-SITE-MAKE-CONTRACT",
+        "info" if not missing_targets else "error",
+        required_targets,
+        {"missing": missing_targets},
+        "No action required." if not missing_targets else "Use scaffold_sync after resolving local managed-file conflicts.",
+    ))
+
+    try:
+        scaffold = _scaffold_sync_plan(project)
+        checks["scaffold"] = {key: value for key, value in scaffold.items() if not key.startswith("_")}
+        drift = len(scaffold["creates"]) + len(scaffold["updates"]) + len(scaffold["adopted"])
+        scaffold_severity = "warning" if scaffold["conflicts"] or drift else "info"
+        scaffold_actual: Any = {"drift": drift, "conflicts": scaffold["conflicts"], "retired": scaffold["retired"]}
+    except RuntimeError as exc:
+        checks["scaffold"] = {"ok": False, "error": str(exc)}
+        scaffold_severity = "warning"
+        scaffold_actual = str(exc)
+    findings.append(_site_doctor_finding(
+        "UW-SITE-SCAFFOLD-DRIFT",
+        scaffold_severity,
+        "managed files match the package baseline",
+        scaffold_actual,
+        "No action required." if scaffold_severity == "info" else "Review scaffold_sync dry-run output; never overwrite reported conflicts.",
+    ))
+
+    inventory = content_inventory(project)
+    computation_required = bool(inventory["computation_sources"] or (project / ".unaltraweb/computations.yml").is_file())
+    capture_required = bool(inventory["web_capture_sources"])
+    visualizations = visualization_status(project, factory_root or project)
+    companion_actions: list[dict[str, str]] = []
+    diagrams = _diagram_status(project)
+    if diagrams["configured"]:
+        companion_actions.append({"owner": "diavisuals", "action": "render_diagram/check style outputs and publish a provider receipt", "reason": "diagram sources are present"})
+    if visualizations["configured"]:
+        companion_actions.append({"owner": "vegavisuals", "action": "visualization_check and publish a provider receipt", "reason": ".vegavisuals.yml is present"})
+
+    diagram_records = diagrams["sources"]
+    diagram_receipt = diagrams["receipt"]
+    diagram_outputs_fresh = all(record["state"] == "fresh" for record in diagram_records)
+    statuses: dict[str, Any] = {"visualizations": visualizations, "diagrams": diagrams}
+    if computation_required:
+        if factory_root is None:
+            statuses["computations"] = {"ok": None, "required": True, "action": "Run manual_computation_check from a factory-backed MCP session."}
+        else:
+            statuses["computations"] = manual_computation_status(project, factory_root)
+    if capture_required:
+        if factory_root is None:
+            statuses["web_captures"] = {"ok": None, "required": True, "action": "Run web_capture_check from a factory-backed MCP session."}
+        else:
+            statuses["web_captures"] = web_capture_status(project, factory_root)
+    checks["generated_freshness"] = statuses
+    for name in ["computations", "web_captures"]:
+        status_value = statuses.get(name)
+        if isinstance(status_value, dict) and status_value.get("ok") is not True:
+            findings.append(_site_doctor_finding(
+                f"UW-SITE-{name.upper().replace('_', '-')}-FRESHNESS",
+                "error",
+                "fresh generated outputs",
+                status_value,
+                f"Run the corresponding {name} check and explicit render workflow, then rerun site_doctor.",
+            ))
+    if visualizations["configured"] and visualizations.get("ok") is not True:
+        findings.append(_site_doctor_finding(
+            "UW-SITE-VISUALIZATION-RECEIPT",
+            "error",
+            "verified vegavisuals provider receipt for current inputs and outputs",
+            visualizations,
+            "Run visualization_check with the selected vegavisuals provider and retain its receipt.",
+        ))
+    if not diagram_outputs_fresh:
+        findings.append(_site_doctor_finding(
+            "UW-SITE-DIAGRAM-FRESHNESS",
+            "error",
+            "fresh diagram SVG outputs",
+            diagram_records,
+            "Use the diavisuals renderer for missing or stale outputs; never replace an edited SVG automatically.",
+        ))
+    if diagram_receipt is not None and diagram_receipt.get("ok") is not True:
+        findings.append(_site_doctor_finding(
+            "UW-SITE-DIAGRAM-RECEIPT",
+            "error",
+            "verified diavisuals provider receipt for current inputs and outputs",
+            diagram_receipt,
+            "Run the selected diavisuals checks and retain their provider receipt.",
+        ))
+    checks["companion_actions"] = companion_actions
+
+    freshness = content_freshness_check(project)
+    overrides = _core_override_inventory(project)
+    build = build_health(project)
+    checks["content_freshness"] = freshness
+    checks["core_overrides"] = overrides
+    checks["build_health"] = build
+    checks["html_audit"] = html_audit(project) if build["site_dir_exists"] else {"ok": None, "reason": "_site is absent"}
+    if build["site_dir_exists"] and checks["html_audit"].get("ok") is not True:
+        findings.append(_site_doctor_finding(
+            "UW-SITE-HTML-AUDIT",
+            "error",
+            "clean generated HTML",
+            checks["html_audit"],
+            "Fix the generated HTML findings and rebuild before publication.",
+        ))
+    findings.append(_site_doctor_finding(
+        "UW-SITE-CONTENT-FRESHNESS",
+        "warning" if freshness["warnings"] else "info",
+        "no local freshness warnings",
+        freshness["warnings"],
+        "No action required." if not freshness["warnings"] else "Review future-dated content and stale bibliometrics before publication.",
+    ))
+    findings.append(_site_doctor_finding(
+        "UW-SITE-CORE-OVERRIDES",
+        "warning" if overrides["symlinks"] else "info",
+        "explicit regular-file core overrides",
+        overrides,
+        "Review overrides when upgrading the core; remove symlinked overrides." if overrides["symlinks"] else "Review this inventory when upgrading the core.",
+    ))
+
+    summary = {severity: sum(item["severity"] == severity for item in findings) for severity in ["error", "warning", "info"]}
+    return {
+        "schema_version": 1,
+        "ok": summary["error"] == 0,
+        "offline": True,
+        "read_only": True,
+        "project": str(project),
+        "distribution": distribution,
+        "summary": summary,
+        "findings": findings,
+        "checks": checks,
+    }
+
+
 def site_check(project: Path, factory: Path, max_bibliometrics_age_days: int = 180) -> dict[str, Any]:
     project = project_path(project)
     checks = {
@@ -2935,6 +4806,7 @@ def site_check(project: Path, factory: Path, max_bibliometrics_age_days: int = 1
         "computations": manual_computation_status(project, factory),
         "web_captures": web_capture_status(project, factory),
         "visualizations": visualization_status(project, factory),
+        "diagrams": _diagram_status(project),
         "bibliography": bibliography_inventory(project),
         "build_health": build_health(project),
     }
@@ -2967,9 +4839,9 @@ def site_context(project: Path, factory: Path | None = None) -> dict[str, Any]:
 
 def list_tools() -> dict[str, Any]:
     return {
-        "resources": ["web://site-context", "web://new-web-scaffolds", "web://starter-templates", "web://profile-contract", "web://manual-writing-guidance", "web://manual-authoring-components", "web://manual-computations", "web://web-captures", "web://profile-prune-plan", "web://content-inventory", "web://language-policy", "web://content-approval", "web://translation-plan", "web://bibliography", "web://bibliometrics", "web://build-health", "web://prompts"],
+        "resources": ["web://distribution", "web://site-context", "web://site-doctor", "web://new-web-scaffolds", "web://starter-templates", "web://profile-contract", "web://manual-writing-guidance", "web://manual-authoring-components", "web://manual-computations", "web://web-captures", "web://profile-prune-plan", "web://content-inventory", "web://language-policy", "web://content-approval", "web://translation-plan", "web://bibliography", "web://bibliometrics", "web://build-health", "web://prompts"],
         "prompts": list(PROMPT_SPECS),
-        "tools": ["new_web", "initialize_site", "starter_templates", "detect_site", "site_context", "site_check", "profile_check", "manual_source_quality_check", "manual_editorial_quality_check", "manual_authoring_capabilities", "manual_computation_status", "manual_computation_check", "manual_computation_render", "manual_computation_render_figures", "web_capture_status", "web_capture_check", "web_capture_render", "manual_pdf_status", "manual_pdf_build", "manual_pdf_publish", "profile_prune_plan", "profile_prune", "content_inventory", "language_policy", "content_approval_inventory", "translation_plan", "content_freshness_check", "bibliography_inventory", "bibliography_add_entry", "bibliometrics_check", "bibliometrics_update", "bibliometrics_fetch_scimago", "build_site", "build_health", "preview_start", "preview_status", "preview_stop", "http_check"],
+        "tools": ["distribution_doctor", "new_web", "initialize_site", "starter_templates", "detect_site", "site_context", "site_doctor", "site_check", "site_source_read", "site_source_write", "site_source_delete", "scaffold_sync", "profile_check", "manual_source_quality_check", "manual_editorial_quality_check", "manual_authoring_capabilities", "manual_computation_status", "manual_computation_check", "manual_computation_render", "manual_computation_render_figures", "web_capture_status", "web_capture_check", "web_capture_render", "manual_pdf_status", "manual_pdf_build", "manual_pdf_publish", "profile_prune_plan", "profile_prune", "content_inventory", "language_policy", "content_approval_inventory", "translation_plan", "content_freshness_check", "bibliography_inventory", "bibliography_add_entry", "bibliometrics_check", "bibliometrics_update", "bibliometrics_fetch_scimago", "build_site", "build_health", "html_audit", "preview_start", "preview_status", "preview_stop", "http_check"],
     }
 
 

--- a/test/mcp_preview_smoke.py
+++ b/test/mcp_preview_smoke.py
@@ -58,6 +58,11 @@ def main() -> None:
         assert status["ok"] is True
         assert status["running"] is True
         assert status["container"].startswith("unaltraweb-preview-")
+
+        checked = site_tools.http_check(project, paths=["/"], timeout_seconds=2)
+        assert checked["ok"] is True, checked
+        assert checked["owned"] is True
+        assert checked["redirects_followed"] == 0
     finally:
         stopped = site_tools.preview_stop(project)
         assert stopped["ok"] is True

--- a/test/mcp_smoke.py
+++ b/test/mcp_smoke.py
@@ -41,10 +41,11 @@ async def smoke() -> None:
             async with ClientSession(read, write) as session:
                 await session.initialize()
                 tools = {tool.name for tool in (await session.list_tools()).tools}
-                for name in ["new_web", "detect_site", "content_inventory", "build_site", "preview_start", "preview_status", "preview_stop"]:
+                for name in ["distribution_doctor", "new_web", "detect_site", "site_doctor", "site_source_read", "site_source_write", "site_source_delete", "scaffold_sync", "content_inventory", "build_site", "html_audit", "preview_start", "preview_status", "preview_stop"]:
                     assert name in tools, name
 
                 resources = {str(resource.uri) for resource in (await session.list_resources()).resources}
+                assert "web://distribution" in resources
                 assert "web://site-context" in resources
                 assert "web://new-web-scaffolds" in resources
                 assert "web://content-inventory" in resources
@@ -60,17 +61,41 @@ async def smoke() -> None:
                 assert initialized["ok"] is True, initialized
                 assert (project / "_config.yml").is_file()
                 assert (project / "Makefile").is_file()
+                assert (project / ".unaltraweb/scaffold.json").is_file()
 
                 detection = tool_payload(await session.call_tool("detect_site", {}))
                 assert detection["is_unaltraweb_site"] is True
                 assert detection["project"] == str(project)
 
+                distribution = tool_payload(await session.call_tool("distribution_doctor", {}))
+                assert distribution["ok"] is True, distribution
+                assert distribution["mode"] == "factory"
+                assert distribution["project"]["profile"] == "unaltreselfie"
+
                 inventory = tool_payload(await session.call_tool("content_inventory", {}))
                 assert inventory["collections"]["_pages"]["documents"] == 1
+
+                home = tool_payload(await session.call_tool("site_source_read", {"path": "_pages/en/index.md"}))
+                source_dry_run = tool_payload(await session.call_tool("site_source_write", {
+                    "path": "_pages/en/index.md",
+                    "content": home["content"] + "\nMCP source smoke.\n",
+                    "expected_sha256": home["sha256"],
+                }))
+                assert source_dry_run["dry_run"] is True
+                assert (project / "_pages/en/index.md").read_text(encoding="utf-8") == home["content"]
+
+                scaffold = tool_payload(await session.call_tool("scaffold_sync", {}))
+                assert scaffold["ok"] is True, scaffold
+                assert scaffold["dry_run"] is True
+
+                doctor = tool_payload(await session.call_tool("site_doctor", {}))
+                assert doctor["ok"] is True, doctor
+                assert doctor["offline"] is True
 
                 build = tool_payload(await session.call_tool("build_site", {}))
                 assert build["ok"] is True, build
                 assert build["nested_container"] is False
+                assert build["html_audit"]["ok"] is True, build["html_audit"]
                 assert (project / "_site/index.html").is_file()
 
                 checks = tool_payload(await session.call_tool("site_check", {}))

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import copy
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from unaltraweb_mcp import __version__, cli, site_tools
+from unaltraweb_mcp.distribution import (
+    component_contract_semantic_errors,
+    component_reference,
+    distribution_contract,
+    distribution_doctor,
+    is_mutable_reference,
+    validate_component_contract,
+)
+from scripts.validate_distribution import publish_ref_errors
+
+
+class DistributionTests(unittest.TestCase):
+    def test_component_contract_covers_the_modular_release(self) -> None:
+        contract = distribution_contract()
+
+        self.assertEqual(contract["schema_version"], 1)
+        self.assertEqual(contract["release"]["version"], __version__)
+        self.assertEqual(
+            set(contract["components"]),
+            {"gem", "wheel", "runtime", "mcp", "compute_python", "compute_r", "web_capture", "manual_pdf", "diavisuals", "vegavisuals"},
+        )
+        self.assertEqual(
+            {name for name, value in contract["components"].items() if value["included_in_wheel"]},
+            {"wheel"},
+        )
+        self.assertTrue(all(value["repository"].startswith("https://") for value in contract["components"].values()))
+        self.assertEqual(contract["receipt_contract"]["input_inventory"], "exact")
+        self.assertEqual(
+            contract["receipt_contract"]["vegavisuals_dependencies"],
+            ["manifest.inputs", "visualizations[].inputs", "spec.data.url"],
+        )
+        self.assertEqual(contract["receipt_contract"]["diavisuals_dependencies"], [])
+
+    def test_doctor_reports_healthy_limited_wheel_mode(self) -> None:
+        result = distribution_doctor()
+
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["offline"])
+        self.assertTrue(result["limited"])
+        self.assertFalse(result["release_ready"])
+        self.assertEqual(result["pending_releases"], ["diavisuals", "vegavisuals"])
+        self.assertEqual(result["unavailable_releases"], [])
+        self.assertEqual(result["receipt_contract"]["input_inventory"], "exact")
+        self.assertEqual(result["mode"], "wheel")
+        self.assertIn("UW-DIST-WHEEL-MODE", {item["code"] for item in result["findings"]})
+        for finding in result["findings"]:
+            self.assertEqual(
+                {"code", "severity", "expected", "actual", "remediation"},
+                {key for key in finding if key != "component"},
+            )
+
+    def test_doctor_treats_unavailable_external_releases_as_not_release_ready(self) -> None:
+        contract = distribution_contract()
+        contract["components"]["vegavisuals"]["release_status"] = "unavailable"
+
+        with patch("unaltraweb_mcp.distribution.distribution_contract", return_value=contract):
+            result = distribution_doctor()
+
+        self.assertTrue(result["ok"])
+        self.assertFalse(result["release_ready"])
+        self.assertEqual(result["pending_releases"], ["diavisuals"])
+        self.assertEqual(result["unavailable_releases"], ["vegavisuals"])
+        self.assertIn("UW-DIST-COMPANION-RELEASE-UNAVAILABLE", {item["code"] for item in result["findings"]})
+
+    def test_doctor_inspects_only_features_selected_by_project_config(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_project:
+            project = Path(raw_project)
+            (project / "_config.yml").write_text(
+                "theme: unaltraweb\nunaltraweb:\n  site_profile: unaltremanual\n  manual:\n    pdf:\n      enabled: true\n",
+                encoding="utf-8",
+            )
+            (project / "Gemfile").write_text('gem "unaltraweb", "= 0.3.0"\n', encoding="utf-8")
+            (project / "Gemfile.lock").write_text("DEPENDENCIES\n  unaltraweb (= 0.3.0)\n", encoding="utf-8")
+            (project / "Makefile").write_text(f"MCP_IMAGE ?= {component_reference('mcp')}\n", encoding="utf-8")
+            (project / ".unaltraweb").mkdir()
+            (project / ".unaltraweb/computations.yml").write_text(
+                "version: 1\nengines:\n  python:\n    image: registry.example/manual:main\n",
+                encoding="utf-8",
+            )
+            (project / ".vegavisuals.yml").write_text("visualizations: []\n", encoding="utf-8")
+            (project / "assets").mkdir()
+            (project / "assets/home.capture.yml").write_text("id: home\n", encoding="utf-8")
+
+            result = distribution_doctor(project=project)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["project"]["profile"], "unaltremanual")
+        self.assertTrue(result["project"]["features"]["manual_computations"])
+        self.assertTrue(result["project"]["features"]["web_captures"])
+        self.assertTrue(result["project"]["features"]["manual_pdf"])
+        self.assertTrue(result["project"]["features"]["vegavisuals"])
+        self.assertIn("manual_pdf", result["selected_components"])
+        self.assertIn("UW-DIST-PROJECT-MUTABLE-PIN", {item["code"] for item in result["findings"]})
+
+    def test_docker_doctor_only_inspects_local_images(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        commands: list[list[str]] = []
+
+        def completed(command, **_kwargs):
+            commands.append(command)
+            if command[1] == "version":
+                return subprocess.CompletedProcess(command, 0, "27.0.0\n", "")
+            return subprocess.CompletedProcess(command, 1, "", "No such image")
+
+        with patch("unaltraweb_mcp.distribution.shutil.which", return_value="/usr/bin/docker"), patch(
+            "unaltraweb_mcp.distribution.run_process", side_effect=completed
+        ):
+            result = distribution_doctor(factory=root, check_docker=True)
+
+        self.assertTrue(result["ok"], result["findings"])
+        self.assertTrue(result["docker"]["checked"])
+        self.assertTrue(any(command[1:3] == ["image", "inspect"] for command in commands))
+        self.assertTrue(all("pull" not in command and "build" not in command for command in commands))
+
+    def test_cli_package_inspection_does_not_require_factory(self) -> None:
+        with tempfile.TemporaryDirectory(), patch.dict(os.environ, {}, clear=True), patch(
+            "unaltraweb_mcp.cli.find_factory_dir", return_value=None
+        ):
+            output = io.StringIO()
+            with redirect_stdout(output):
+                returncode = cli.main(["mcp", "list-tools"])
+            inventory = json.loads(output.getvalue())
+            self.assertEqual(returncode, 0)
+            self.assertIn("distribution_doctor", inventory["tools"])
+
+            with self.assertRaisesRegex(SystemExit, "requires the unaltraweb factory checkout"):
+                cli.main(["mcp", "prompts"])
+
+    def test_factory_discovery_rejects_an_unrelated_factory_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            unrelated = root / "diavisuals"
+            empty = root / "installed-wheel"
+            unrelated.mkdir()
+            empty.mkdir()
+            manifest = unrelated / "mcp-factory.yml"
+            manifest.write_text("name: diavisuals\n", encoding="utf-8")
+
+            with patch.dict(os.environ, {"UNALTRAWEB_FACTORY_DIR": str(unrelated)}, clear=True), patch(
+                "unaltraweb_mcp.cli.Path.cwd", return_value=unrelated
+            ), patch("unaltraweb_mcp.cli.source_root", return_value=empty):
+                self.assertIsNone(cli.find_factory_dir())
+                manifest.write_text("name: unaltraweb\n", encoding="utf-8")
+                self.assertEqual(cli.find_factory_dir(), unrelated.resolve())
+
+    def test_cli_build_site_propagates_failed_ok_status(self) -> None:
+        output = io.StringIO()
+        with patch("unaltraweb_mcp.cli.factory_dir", return_value=Path("/tmp/factory")), patch(
+            "unaltraweb_mcp.cli.tools.build_site",
+            return_value={"ok": False, "returncode": 0, "error": "HTML audit failed"},
+        ), redirect_stdout(output):
+            returncode = cli.main(["--project", "/tmp/site", "mcp", "build-site"])
+
+        self.assertEqual(returncode, 1)
+        self.assertFalse(json.loads(output.getvalue())["ok"])
+
+    def test_wheel_contract_inventory_matches_every_cli_mcp_command(self) -> None:
+        parser = cli.build_parser()
+        top_subparsers = next(action for action in parser._actions if hasattr(action, "choices") and action.choices)
+        mcp_parser = top_subparsers.choices["mcp"]
+        mcp_subparsers = next(action for action in mcp_parser._actions if hasattr(action, "choices") and action.choices)
+        actual = set(mcp_subparsers.choices)
+        contract = distribution_contract()["wheel_contract"]
+
+        self.assertEqual(set(top_subparsers.choices), cli.PACKAGE_ONLY_COMMANDS | cli.FACTORY_REQUIRED_COMMANDS | {"mcp"})
+        self.assertEqual(set(contract["package_only_commands"]), cli.PACKAGE_ONLY_COMMANDS)
+        self.assertEqual(set(contract["factory_required_commands"]), cli.FACTORY_REQUIRED_COMMANDS)
+        self.assertEqual(actual, cli.ALL_MCP_COMMANDS)
+        self.assertEqual(set(contract["package_only_mcp"]), cli.PACKAGE_ONLY_MCP_COMMANDS)
+        self.assertEqual(set(contract["factory_required_mcp"]), cli.FACTORY_REQUIRED_MCP_COMMANDS)
+        self.assertEqual(set(contract["package_only_mcp"]) | set(contract["factory_required_mcp"]), actual)
+
+    def test_component_contract_schema_and_semantics_are_enforced(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        schema = json.loads((root / "src/unaltraweb_mcp/component-contract.schema.json").read_text(encoding="utf-8"))
+        contract = distribution_contract()
+        validate_component_contract(contract, schema)
+        self.assertEqual(component_contract_semantic_errors(contract), [])
+
+        extra = copy.deepcopy(contract)
+        extra["components"]["wheel"]["unexpected"] = True
+        with self.assertRaisesRegex(RuntimeError, "not allowed"):
+            validate_component_contract(extra, schema)
+
+        inconsistent = copy.deepcopy(contract)
+        inconsistent["components"]["wheel"]["reference"] = "unaltraweb-mcp==9.9.9"
+        self.assertIn("wheel wheel reference does not match its version", component_contract_semantic_errors(inconsistent))
+
+    def test_release_pin_classifier_rejects_mutable_channels(self) -> None:
+        self.assertTrue(is_mutable_reference("ghcr.io/example/worker:main"))
+        self.assertTrue(is_mutable_reference("https://github.com/example/tool.git@refs/heads/main"))
+        self.assertTrue(is_mutable_reference("ghcr.io/example/worker"))
+        self.assertTrue(is_mutable_reference("registry.example:5000/team/worker"))
+        self.assertTrue(is_mutable_reference("registry.example:5000/team/worker:latest"))
+        self.assertFalse(is_mutable_reference("ghcr.io/example/worker:0.3.0"))
+        self.assertFalse(is_mutable_reference("registry.example:5000/team/worker:0.3.0"))
+        self.assertFalse(is_mutable_reference("ghcr.io/example/worker@sha256:" + "a" * 64))
+        self.assertTrue(is_mutable_reference("ghcr.io/example/worker@sha256:invalid"))
+        self.assertTrue(is_mutable_reference("ghcr.io/example/worker:"))
+
+    def test_distribution_validator_passes_repository_contract(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        completed = subprocess.run(
+            [sys.executable, str(root / "scripts/validate_distribution.py")],
+            cwd=root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr or completed.stdout)
+        result = json.loads(completed.stdout)
+        self.assertTrue(result["ok"])
+        self.assertFalse(result["release_ready"])
+        self.assertEqual(result["pending_releases"], ["diavisuals", "vegavisuals"])
+
+        release = subprocess.run(
+            [sys.executable, str(root / "scripts/validate_distribution.py"), "--require-release-ready"],
+            cwd=root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(release.returncode, 2, release.stderr or release.stdout)
+        self.assertFalse(json.loads(release.stdout)["release_ready"])
+
+    def test_publish_ref_must_match_the_distribution_release(self) -> None:
+        contract = distribution_contract()
+
+        self.assertEqual(publish_ref_errors(
+            contract,
+            ref_type="tag",
+            ref_name="v0.3.0",
+            default_branch="main",
+            component_ids=["runtime", "mcp"],
+        ), [])
+        self.assertEqual(publish_ref_errors(
+            contract,
+            ref_type="branch",
+            ref_name="main",
+            default_branch="main",
+            component_ids=["runtime"],
+        ), [])
+        self.assertIn("publish ref must be", publish_ref_errors(
+            contract,
+            ref_type="tag",
+            ref_name="v9.9.9",
+            default_branch="main",
+            component_ids=["runtime"],
+        )[-1])
+
+    def test_gemspec_packages_contract_schema_and_requires_bundler_four_ruby(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        gemspec = (root / "unaltraweb.gemspec").read_text(encoding="utf-8")
+        self.assertIn('spec.required_ruby_version = ">= 3.2"', gemspec)
+        self.assertGreaterEqual(gemspec.count('"src/unaltraweb_mcp/component-contract.schema.json"'), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_mcp_manual_computations.py
+++ b/test/test_mcp_manual_computations.py
@@ -127,14 +127,42 @@ Chapter source.
             with self.assertRaisesRegex(ValueError, "unsafe for Make delegation"):
                 site_tools.run_factory_make(Path("/tmp/factory"), Path("/tmp/site"), "manual-compute-status")
 
-    @patch("unaltraweb_mcp.site_tools.subprocess.run")
+    @patch("unaltraweb_mcp.site_tools.run_process")
     def test_factory_delegation_accepts_spaces_in_project_path(self, run) -> None:
-        run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        run.return_value = subprocess.CompletedProcess([], 0, '{"ok": true}', "")
         with patch("unaltraweb_mcp.site_tools.project_path", side_effect=[Path("/tmp/factory"), Path("/tmp/My Site")]):
             result = site_tools.run_factory_make(Path("/tmp/factory"), Path("/tmp/site"), "manual-compute-status")
 
         self.assertTrue(result["ok"])
         self.assertIn("PROJECT=/tmp/My Site", run.call_args.args[0])
+
+    @patch("unaltraweb_mcp.site_tools.run_process")
+    def test_factory_delegation_fails_closed_on_invalid_or_truncated_json(self, run) -> None:
+        run.return_value = site_tools.ProcessResult(
+            args=["make"],
+            returncode=0,
+            stdout='{"ok": true',
+            stderr="",
+            timed_out=False,
+            stdout_truncated=False,
+            stderr_truncated=False,
+        )
+        invalid = site_tools.run_factory_make(Path("/tmp/factory"), Path("/tmp/site"), "manual-compute-status")
+        self.assertFalse(invalid["ok"])
+        self.assertIn("invalid JSON", invalid["output_error"])
+
+        run.return_value = site_tools.ProcessResult(
+            args=["make"],
+            returncode=0,
+            stdout='{"ok": true}',
+            stderr="",
+            timed_out=False,
+            stdout_truncated=True,
+            stderr_truncated=False,
+        )
+        truncated = site_tools.run_factory_make(Path("/tmp/factory"), Path("/tmp/site"), "manual-compute-status")
+        self.assertFalse(truncated["ok"])
+        self.assertIn("truncated", truncated["output_error"])
 
     def test_factory_make_preserves_project_path_with_spaces(self) -> None:
         root = Path(__file__).resolve().parents[1]

--- a/test/test_mcp_runtime.py
+++ b/test/test_mcp_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 import subprocess
 import tempfile
@@ -291,9 +292,9 @@ class McpRuntimeTests(unittest.TestCase):
             site_tools.preview_status(self.project)
 
     @patch("unaltraweb_mcp.site_tools.time.sleep", return_value=None)
-    @patch("unaltraweb_mcp.site_tools.http_check")
+    @patch("unaltraweb_mcp.site_tools._http_probe")
     @patch("unaltraweb_mcp.site_tools._preview_inspect")
-    def test_existing_preview_waits_until_ready(self, inspect, http_check, _sleep) -> None:
+    def test_existing_preview_waits_until_ready(self, inspect, http_probe, _sleep) -> None:
         _, project_id, _ = site_tools._preview_identity(self.project)
         info = {
             "Config": {"Labels": {
@@ -308,15 +309,15 @@ class McpRuntimeTests(unittest.TestCase):
             "NetworkSettings": {"Networks": {"bridge": {"IPAddress": "172.17.0.2"}}},
         }
         inspect.return_value = info
-        http_check.side_effect = [{"ok": False}, {"ok": True}]
+        http_probe.side_effect = [{"ok": False}, {"ok": True}]
 
         result = site_tools.preview_start(self.project, timeout_seconds=10)
 
         self.assertTrue(result["ok"])
         self.assertTrue(result["already_running"])
-        self.assertEqual(http_check.call_count, 2)
+        self.assertEqual(http_probe.call_count, 2)
 
-    @patch("unaltraweb_mcp.site_tools.http_check", return_value={"ok": True})
+    @patch("unaltraweb_mcp.site_tools._http_probe", return_value={"ok": True})
     @patch("unaltraweb_mcp.site_tools._preview_inspect")
     @patch("unaltraweb_mcp.site_tools._docker")
     def test_preview_uses_controller_image_id(self, docker, inspect, _http_check) -> None:
@@ -344,7 +345,23 @@ class McpRuntimeTests(unittest.TestCase):
         self.assertIn("sha256:controller", run_args)
         self.assertEqual(run_args[run_args.index("--entrypoint") + 2], "sha256:controller")
 
-    def test_bootstrap_names_and_labels_stdio_container_by_project(self) -> None:
+    def test_project_id_matches_preview_identity(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+
+        completed = subprocess.run(
+            ["/bin/sh", str(root / "scripts/unaltraweb-mcp-project-id.sh"), str(self.project)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        expected = hashlib.sha256(str(self.project.resolve()).encode("utf-8")).hexdigest()[:16]
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stdout.strip(), expected)
+        self.assertEqual(site_tools._preview_identity(self.project)[1], expected)
+
+    def test_bootstrap_labels_stdio_container_without_a_colliding_name(self) -> None:
         root = Path(__file__).resolve().parents[1]
         fake_bin = self.project / "bin"
         fake_bin.mkdir()
@@ -371,9 +388,10 @@ class McpRuntimeTests(unittest.TestCase):
 
         self.assertEqual(completed.returncode, 0, completed.stderr)
         args = capture.read_text(encoding="utf-8").splitlines()
-        self.assertIn("--name", args)
-        self.assertTrue(args[args.index("--name") + 1].startswith("unaltraweb-mcp-"))
+        project_id = hashlib.sha256(str(self.project.resolve()).encode("utf-8")).hexdigest()[:16]
+        self.assertNotIn("--name", args)
         self.assertIn("io.context.mcp-role=stdio", args)
+        self.assertIn(f"io.context.mcp-project={project_id}", args)
         self.assertIn("sha256:controller", args)
         self.assertNotIn(str(root), args)
         canonical_mount = f"{self.project.resolve()}:{self.project.resolve()}"
@@ -381,15 +399,75 @@ class McpRuntimeTests(unittest.TestCase):
         self.assertEqual(args[args.index("-w") + 1], str(self.project.resolve()))
         self.assertEqual(args[args.index("--project") + 1], str(self.project.resolve()))
 
-    def test_visualization_status_delegates_configured_project_to_companion_mcp(self) -> None:
+    def test_make_cleanup_scopes_project_and_maintainer_targets(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        fake_bin = self.project / "bin"
+        fake_bin.mkdir()
+        capture = self.project / "docker-calls"
+        docker = fake_bin / "docker"
+        docker.write_text(
+            "#!/bin/sh\n"
+            "printf '%s\\n' CALL \"$@\" >> \"$CAPTURE\"\n",
+            encoding="utf-8",
+        )
+        docker.chmod(0o755)
+        env = os.environ.copy()
+        env.update({"PATH": f"{fake_bin}:{env['PATH']}", "CAPTURE": str(capture)})
+
+        def run_target(target: str) -> list[list[str]]:
+            capture.unlink(missing_ok=True)
+            completed = subprocess.run(
+                [
+                    "make", "--silent", "--no-print-directory", "-C", str(root), target,
+                    f"PROJECT={self.project}",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            calls: list[list[str]] = []
+            for line in capture.read_text(encoding="utf-8").splitlines():
+                if line == "CALL":
+                    calls.append([])
+                else:
+                    calls[-1].append(line)
+            return calls
+
+        project_id = hashlib.sha256(str(self.project.resolve()).encode("utf-8")).hexdigest()[:16]
+        self.assertEqual(
+            run_target("mcp-down"),
+            [
+                [
+                    "ps", "-aq", "--filter", "label=io.context.mcp-factory=unaltraweb",
+                    "--filter", f"label=io.context.mcp-project={project_id}",
+                ],
+                [
+                    "network", "ls", "-q", "--filter", "label=io.context.mcp-factory=unaltraweb",
+                    "--filter", f"label=io.context.mcp-project={project_id}",
+                ],
+            ],
+        )
+        self.assertEqual(
+            run_target("mcp-down-all"),
+            [
+                ["ps", "-aq", "--filter", "label=io.context.mcp-factory=unaltraweb"],
+                ["network", "ls", "-q", "--filter", "label=io.context.mcp-factory=unaltraweb"],
+            ],
+        )
+
+    def test_visualization_status_requires_provider_receipt_for_configured_project(self) -> None:
         (self.project / ".vegavisuals.yml").write_text("visualizations: []\n", encoding="utf-8")
 
         status = site_tools.visualization_status(self.project, Path("/opt/unaltraweb"))
 
-        self.assertTrue(status["ok"])
-        self.assertTrue(status["delegated"])
+        self.assertFalse(status["ok"])
+        self.assertFalse(status["delegated"])
         self.assertEqual(status["owner"], "vegavisuals")
         self.assertEqual(status["required_tool"], "visualization_check")
+        self.assertEqual(status["receipt"]["state"], "missing")
 
     def test_inventory_exposes_runtime_tools(self) -> None:
         tools = site_tools.list_tools()["tools"]
@@ -418,6 +496,15 @@ class McpRuntimeTests(unittest.TestCase):
         self.assertEqual(set(manifest["mcp"]["required_tools"]), set(inventory["tools"]))
         self.assertIn("context", manifest["workspace_rule"]["init_creates"])
         self.assertIn("context", manifest["workspace_rule"]["source_paths"])
+        self.assertEqual(manifest["schema_version"], 1)
+        self.assertEqual(
+            manifest["transport"]["command"],
+            ["make", "-C", "${factoryRoot}", "mcp-stdio", "PROJECT=${workspaceFolder}"],
+        )
+        self.assertNotIn("init", manifest["commands"])
+        self.assertNotIn("down", manifest["commands"])
+        self.assertTrue(all(not dependency["init"] for dependency in manifest["mcp_dependencies"]))
+        self.assertNotIn("mcp-init:", (root / "Makefile").read_text(encoding="utf-8"))
 
     def test_writing_profile_is_excluded_from_published_site(self) -> None:
         root = Path(__file__).resolve().parents[1]

--- a/test/test_site_management_quality.py
+++ b/test/test_site_management_quality.py
@@ -1,0 +1,784 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from unaltraweb_mcp import site_tools
+from unaltraweb_mcp.processes import run_process
+
+
+class SiteManagementQualityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.project = self.root / "site"
+        site_tools.new_web(self.project, site_profile_value="unaltreselfie", title="Quality site")
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_site_source_allowed_path_matrix_and_content_validation(self) -> None:
+        valid = {
+            "_pages/new.md": "---\ntitle: New\n---\nText\n",
+            "_documentation/guide.html": "<p>Guide</p>\n",
+            "_data/items.yml": "items: []\n",
+            "_data/items.json": '{"items": []}\n',
+            "_data/items.csv": "name,value\na,1\n",
+            "context/policy.markdown": "# Policy\n",
+        }
+        for path, content in valid.items():
+            with self.subTest(path=path):
+                result = site_tools.site_source_write(self.project, path, content, create_only=True)
+                self.assertTrue(result["ok"])
+                self.assertTrue(result["dry_run"])
+
+        invalid = [
+            "Makefile",
+            "Gemfile",
+            ".github/workflows/deploy.yml",
+            "_layouts/page.html",
+            "_plugins/unsafe.rb",
+            "_sass/theme.scss",
+            "_bibliography/references.bib",
+            "assets/image.svg",
+            "_site/index.html",
+            "tmp/output.md",
+            "_data/script.py",
+            "context/settings.yml",
+            "../outside.md",
+            "/tmp/outside.md",
+        ]
+        for path in invalid:
+            with self.subTest(path=path), self.assertRaises(ValueError):
+                site_tools.site_source_write(self.project, path, "text", create_only=True)
+
+        with self.assertRaises(ValueError):
+            site_tools.site_source_write(self.project, "_data/bad.json", "{", create_only=True)
+        with self.assertRaises(ValueError):
+            site_tools.site_source_write(self.project, "_data/bad.yml", "key: [", create_only=True)
+        with self.assertRaises(ValueError):
+            site_tools.site_source_write(self.project, "_pages/nul.md", "bad\x00value", create_only=True)
+
+    def test_site_source_dry_run_cas_apply_and_delete(self) -> None:
+        path = "_pages/en/index.md"
+        before = site_tools.site_source_read(self.project, path)
+        proposed = before["content"] + "\nUpdated.\n"
+
+        dry_run = site_tools.site_source_write(
+            self.project,
+            path,
+            proposed,
+            expected_sha256=before["sha256"],
+        )
+        self.assertTrue(dry_run["diff"]["text"])
+        self.assertEqual(site_tools.site_source_read(self.project, path)["sha256"], before["sha256"])
+
+        applied = site_tools.site_source_write(
+            self.project,
+            path,
+            proposed,
+            expected_sha256=before["sha256"],
+            dry_run=False,
+        )
+        self.assertEqual(site_tools.site_source_read(self.project, path)["sha256"], applied["sha256"])
+        with self.assertRaises(RuntimeError):
+            site_tools.site_source_write(
+                self.project,
+                path,
+                proposed + "again\n",
+                expected_sha256=before["sha256"],
+                dry_run=False,
+            )
+
+        created = site_tools.site_source_write(
+            self.project,
+            "_pages/en/delete-me.md",
+            "---\ntitle: Delete me\n---\n",
+            create_only=True,
+            dry_run=False,
+        )
+        delete_dry_run = site_tools.site_source_delete(
+            self.project,
+            "_pages/en/delete-me.md",
+            expected_sha256=created["sha256"],
+        )
+        self.assertTrue(delete_dry_run["dry_run"])
+        with self.assertRaises(RuntimeError):
+            site_tools.site_source_delete(
+                self.project,
+                "_pages/en/delete-me.md",
+                expected_sha256=created["sha256"],
+                dry_run=False,
+            )
+        site_tools.site_source_delete(
+            self.project,
+            "_pages/en/delete-me.md",
+            expected_sha256=created["sha256"],
+            dry_run=False,
+            confirm_delete=True,
+        )
+        self.assertFalse((self.project / "_pages/en/delete-me.md").exists())
+        config_hash = site_tools.site_source_read(self.project, "_config.yml")["sha256"]
+        with self.assertRaises(ValueError):
+            site_tools.site_source_delete(self.project, "_config.yml", expected_sha256=config_hash)
+
+    def test_site_source_rejects_symlinks_and_raced_updates(self) -> None:
+        outside = self.root / "outside.md"
+        outside.write_text("outside\n", encoding="utf-8")
+        (self.project / "_pages/link.md").symlink_to(outside)
+        with self.assertRaises(RuntimeError):
+            site_tools.site_source_read(self.project, "_pages/link.md")
+
+        path = "_pages/en/index.md"
+        before = site_tools.site_source_read(self.project, path)
+        original = site_tools._atomic_site_source_write
+
+        def race(root_fd, relative, content, *, create_only, expected_sha256):
+            (self.project / relative).write_text("raced\n", encoding="utf-8")
+            return original(
+                root_fd,
+                relative,
+                content,
+                create_only=create_only,
+                expected_sha256=expected_sha256,
+            )
+
+        with patch("unaltraweb_mcp.site_tools._atomic_site_source_write", side_effect=race):
+            with self.assertRaisesRegex(RuntimeError, "changed after preflight"):
+                site_tools.site_source_write(
+                    self.project,
+                    path,
+                    before["content"] + "new\n",
+                    expected_sha256=before["sha256"],
+                    dry_run=False,
+                )
+        self.assertEqual((self.project / path).read_text(encoding="utf-8"), "raced\n")
+        self.assertEqual(outside.read_text(encoding="utf-8"), "outside\n")
+
+    def test_site_source_detects_final_window_update_and_delete_edits(self) -> None:
+        path = "_pages/en/index.md"
+        before = site_tools.site_source_read(self.project, path)
+        original_link = os.link
+        update_raced = False
+
+        def race_update(source, destination, *args, **kwargs):
+            nonlocal update_raced
+            if destination == "index.md" and not update_raced:
+                update_raced = True
+                backup = next((self.project / "_pages/en").glob(".unaltraweb-source-backup-*"))
+                backup.write_text("final-window edit\n", encoding="utf-8")
+            return original_link(source, destination, *args, **kwargs)
+
+        with patch("unaltraweb_mcp.site_tools.os.link", side_effect=race_update):
+            with self.assertRaisesRegex(RuntimeError, "final update window"):
+                site_tools.site_source_write(
+                    self.project,
+                    path,
+                    before["content"] + "proposed\n",
+                    expected_sha256=before["sha256"],
+                    dry_run=False,
+                )
+        self.assertEqual((self.project / path).read_text(encoding="utf-8"), "final-window edit\n")
+
+        delete_path = "_pages/en/delete-race.md"
+        created = site_tools.site_source_write(
+            self.project,
+            delete_path,
+            "delete baseline\n",
+            create_only=True,
+            dry_run=False,
+        )
+        delete_raced = False
+
+        def race_delete(source, destination, *args, **kwargs):
+            nonlocal delete_raced
+            if str(destination).endswith("-audit") and not delete_raced:
+                delete_raced = True
+                tombstone = next((self.project / "_pages/en").glob(".unaltraweb-source-delete-*"))
+                tombstone.write_text("delete-window edit\n", encoding="utf-8")
+            return original_link(source, destination, *args, **kwargs)
+
+        with patch("unaltraweb_mcp.site_tools.os.link", side_effect=race_delete):
+            with self.assertRaisesRegex(RuntimeError, "final delete window"):
+                site_tools.site_source_delete(
+                    self.project,
+                    delete_path,
+                    expected_sha256=created["sha256"],
+                    dry_run=False,
+                    confirm_delete=True,
+                )
+        self.assertEqual((self.project / delete_path).read_text(encoding="utf-8"), "delete-window edit\n")
+
+    def test_site_source_rejects_special_oversize_and_non_strict_data(self) -> None:
+        fifo = self.project / "_pages/fifo.md"
+        os.mkfifo(fifo)
+        with self.assertRaisesRegex(ValueError, "regular file"):
+            site_tools.site_source_read(self.project, "_pages/fifo.md")
+
+        oversize = self.project / "_pages/oversize.md"
+        with oversize.open("wb") as stream:
+            stream.truncate(site_tools.SITE_SOURCE_MAX_BYTES + 1)
+        with self.assertRaisesRegex(ValueError, "byte limit"):
+            site_tools.site_source_read(self.project, "_pages/oversize.md")
+
+        with self.assertRaisesRegex(ValueError, "non-finite"):
+            site_tools.site_source_write(self.project, "_data/nonfinite.json", '{"value": NaN}\n', create_only=True)
+        with self.assertRaisesRegex(ValueError, "duplicate YAML key"):
+            site_tools.site_source_write(self.project, "_data/duplicate.yml", "value: one\nvalue: two\n", create_only=True)
+        with self.assertRaisesRegex(ValueError, "duplicate JSON key"):
+            site_tools.site_source_write(self.project, "_data/duplicate.json", '{"value": 1, "value": 2}\n', create_only=True)
+
+    def test_profile_prune_empty_directory_cleanup_never_follows_symlinks(self) -> None:
+        project = self.root / "prune-site"
+        outside = self.root / "outside-content"
+        (outside / "empty").mkdir(parents=True)
+        project.mkdir()
+        (project / "_pages").symlink_to(outside, target_is_directory=True)
+        (project / "_posts").mkdir()
+        (project / "_posts/outside").symlink_to(outside, target_is_directory=True)
+        (project / "_chapters/empty/deep").mkdir(parents=True)
+        (project / "_config.yml").write_text(
+            "theme: unaltraweb\nunaltraweb:\n  site_profile: unaltreselfie\n",
+            encoding="utf-8",
+        )
+
+        result = site_tools.profile_prune(project, dry_run=False, confirm_prune=True)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(set(result["empty_dirs_removed"]), {"_chapters/empty/deep", "_chapters/empty"})
+        self.assertTrue((project / "_pages").is_symlink())
+        self.assertTrue((project / "_posts/outside").is_symlink())
+        self.assertTrue((outside / "empty").is_dir())
+
+        protected = outside / "protected.md"
+        protected.write_text("---\nprofiles: [unaltremanual]\n---\nProtected\n", encoding="utf-8")
+        raced_plan = {
+            "project": str(project),
+            "site_profile": "unaltreselfie",
+            "candidate_count": 1,
+            "candidates": [{"path": "_posts/outside/protected.md", "profiles": ["unaltremanual"], "title": ""}],
+            "kept_profiled_count": 0,
+            "kept_profiled_sample": [],
+            "unprofiled_count": 0,
+            "unprofiled_sample": [],
+            "rule": "test plan",
+        }
+        with patch("unaltraweb_mcp.site_tools.profile_prune_plan", return_value=raced_plan):
+            confined = site_tools.profile_prune(project, dry_run=False, confirm_prune=True)
+        self.assertEqual(confined["deleted"], [])
+        self.assertEqual(confined["skipped"][0]["path"], "_posts/outside/protected.md")
+        self.assertTrue(protected.is_file())
+
+    def test_scaffold_sync_updates_baseline_files_and_never_overwrites_conflicts(self) -> None:
+        original_payloads = site_tools._managed_scaffold_payloads()
+        updated_payloads = dict(original_payloads)
+        updated_payloads[Path("Makefile")] += b"\n# package update\n"
+
+        with patch("unaltraweb_mcp.site_tools._managed_scaffold_payloads", return_value=updated_payloads):
+            dry_run = site_tools.scaffold_sync(self.project)
+            self.assertEqual([item["path"] for item in dry_run["updates"]], ["Makefile"])
+            self.assertFalse(dry_run["applied"])
+            applied = site_tools.scaffold_sync(self.project, dry_run=False, confirm_sync=True)
+            self.assertTrue(applied["applied"])
+        self.assertTrue((self.project / "Makefile").read_bytes().endswith(b"# package update\n"))
+
+        conflict_site = self.root / "conflict"
+        site_tools.new_web(conflict_site)
+        (conflict_site / "Makefile").write_text("locally edited\n", encoding="utf-8")
+        gemfile_before = (conflict_site / "Gemfile").read_bytes()
+        with patch("unaltraweb_mcp.site_tools._managed_scaffold_payloads", return_value=updated_payloads):
+            conflict = site_tools.scaffold_sync(conflict_site, dry_run=False, confirm_sync=True)
+        self.assertFalse(conflict["ok"])
+        self.assertFalse(conflict["applied"])
+        self.assertEqual((conflict_site / "Makefile").read_text(encoding="utf-8"), "locally edited\n")
+        self.assertEqual((conflict_site / "Gemfile").read_bytes(), gemfile_before)
+
+    def test_scaffold_sync_creates_only_new_missing_managed_paths(self) -> None:
+        manifest_path = self.project / ".unaltraweb/scaffold.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["files"].pop(".gitignore")
+        manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        (self.project / ".gitignore").unlink()
+
+        result = site_tools.scaffold_sync(self.project, dry_run=False, confirm_sync=True)
+
+        self.assertTrue(result["applied"])
+        self.assertEqual([item["path"] for item in result["creates"]], [".gitignore"])
+        self.assertEqual((self.project / ".gitignore").read_bytes(), site_tools._managed_scaffold_payloads()[Path(".gitignore")])
+
+    def test_scaffold_sync_rechecks_every_target_before_applying(self) -> None:
+        payloads = site_tools._managed_scaffold_payloads()
+        updated = dict(payloads)
+        updated[Path("Makefile")] += b"\n# update one\n"
+        updated[Path("Gemfile")] += b"\n# update two\n"
+        gemfile_before = (self.project / "Gemfile").read_bytes()
+        original_recheck = site_tools._recheck_scaffold_sync
+
+        def race(root_fd, plan):
+            (self.project / "Makefile").write_text("raced local edit\n", encoding="utf-8")
+            return original_recheck(root_fd, plan)
+
+        with patch("unaltraweb_mcp.site_tools._managed_scaffold_payloads", return_value=updated), patch(
+            "unaltraweb_mcp.site_tools._recheck_scaffold_sync",
+            side_effect=race,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "changed after scaffold_sync preflight"):
+                site_tools.scaffold_sync(self.project, dry_run=False, confirm_sync=True)
+
+        self.assertEqual((self.project / "Makefile").read_text(encoding="utf-8"), "raced local edit\n")
+        self.assertEqual((self.project / "Gemfile").read_bytes(), gemfile_before)
+
+    def test_scaffold_sync_rolls_back_all_files_and_manifest_on_apply_failure(self) -> None:
+        payloads = site_tools._managed_scaffold_payloads()
+        updated = dict(payloads)
+        updated[Path("Makefile")] += b"\n# transaction one\n"
+        updated[Path("Gemfile")] += b"\n# transaction two\n"
+        before = {
+            path: (self.project / path).read_bytes()
+            for path in [Path("Makefile"), Path("Gemfile"), site_tools.SCAFFOLD_MANIFEST_PATH]
+        }
+        original_commit = site_tools._commit_staged_managed_write
+
+        def fail_second(staged, *, expected_sha256=""):
+            if staged["relative"] == Path("Gemfile"):
+                raise RuntimeError("injected second-file failure")
+            return original_commit(staged, expected_sha256=expected_sha256)
+
+        with patch("unaltraweb_mcp.site_tools._managed_scaffold_payloads", return_value=updated), patch(
+            "unaltraweb_mcp.site_tools._commit_staged_managed_write",
+            side_effect=fail_second,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "injected second-file failure"):
+                site_tools.scaffold_sync(self.project, dry_run=False, confirm_sync=True)
+
+        for path, content in before.items():
+            self.assertEqual((self.project / path).read_bytes(), content)
+        self.assertFalse(list(self.project.rglob(".unaltraweb-scaffold-*")))
+
+    def test_scaffold_sync_preserves_a_final_window_local_edit(self) -> None:
+        payloads = site_tools._managed_scaffold_payloads()
+        updated = dict(payloads)
+        updated[Path("Makefile")] += b"\n# proposed package update\n"
+        manifest_before = (self.project / site_tools.SCAFFOLD_MANIFEST_PATH).read_bytes()
+        original_link = os.link
+        raced = False
+
+        def race_managed_update(source, destination, *args, **kwargs):
+            nonlocal raced
+            if destination == "Makefile" and not raced:
+                raced = True
+                backup = next(self.project.glob(".unaltraweb-scaffold-backup-*"))
+                backup.write_text("final managed edit\n", encoding="utf-8")
+            return original_link(source, destination, *args, **kwargs)
+
+        with patch("unaltraweb_mcp.site_tools._managed_scaffold_payloads", return_value=updated), patch(
+            "unaltraweb_mcp.site_tools.os.link",
+            side_effect=race_managed_update,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "final scaffold_sync window"):
+                site_tools.scaffold_sync(self.project, dry_run=False, confirm_sync=True)
+
+        self.assertEqual((self.project / "Makefile").read_text(encoding="utf-8"), "final managed edit\n")
+        self.assertEqual((self.project / site_tools.SCAFFOLD_MANIFEST_PATH).read_bytes(), manifest_before)
+
+    def test_scaffold_sync_rechecks_unchanged_and_adopted_files_before_manifest_commit(self) -> None:
+        for state, target_name in [("unchanged", "Gemfile"), ("adopted", ".gitignore")]:
+            with self.subTest(state=state):
+                project = self.root / f"final-recheck-{state}"
+                site_tools.new_web(project)
+                manifest_path = project / site_tools.SCAFFOLD_MANIFEST_PATH
+                if state == "adopted":
+                    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                    manifest["files"].pop(target_name)
+                    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+                manifest_before = manifest_path.read_bytes()
+                makefile_before = (project / "Makefile").read_bytes()
+                payloads = site_tools._managed_scaffold_payloads()
+                updated = dict(payloads)
+                updated[Path("Makefile")] += b"\n# package transaction\n"
+                original_verify = site_tools._verify_applied_managed_transaction
+                raced = False
+
+                def race_before_manifest(applied):
+                    nonlocal raced
+                    original_verify(applied)
+                    if not raced:
+                        raced = True
+                        (project / target_name).write_text(f"raced {state}\n", encoding="utf-8")
+
+                with patch("unaltraweb_mcp.site_tools._managed_scaffold_payloads", return_value=updated), patch(
+                    "unaltraweb_mcp.site_tools._verify_applied_managed_transaction",
+                    side_effect=race_before_manifest,
+                ):
+                    with self.assertRaisesRegex(RuntimeError, "before scaffold_sync manifest commit"):
+                        site_tools.scaffold_sync(project, dry_run=False, confirm_sync=True)
+
+                self.assertEqual((project / target_name).read_text(encoding="utf-8"), f"raced {state}\n")
+                self.assertEqual((project / "Makefile").read_bytes(), makefile_before)
+                self.assertEqual(manifest_path.read_bytes(), manifest_before)
+
+    def test_new_web_publishes_scaffold_manifest_last(self) -> None:
+        project = self.root / "manifest-last"
+        created: list[Path] = []
+        original_create = site_tools._create_scaffold_file
+
+        def record(root_fd, relative, content):
+            created.append(relative)
+            return original_create(root_fd, relative, content)
+
+        with patch("unaltraweb_mcp.site_tools._create_scaffold_file", side_effect=record):
+            site_tools.new_web(project)
+
+        self.assertEqual(created[-1], site_tools.SCAFFOLD_MANIFEST_PATH)
+
+    def test_site_doctor_is_strict_offline_and_inventories_overrides(self) -> None:
+        (self.project / "_layouts").mkdir()
+        (self.project / "_layouts/custom.html").write_text("custom\n", encoding="utf-8")
+
+        result = site_tools.site_doctor(self.project)
+
+        self.assertTrue(result["ok"], result["findings"])
+        self.assertTrue(result["offline"])
+        self.assertTrue(result["read_only"])
+        self.assertIn("_layouts/custom.html", result["checks"]["core_overrides"]["files"])
+        self.assertIn("UW-SITE-SCAFFOLD-DRIFT", {item["code"] for item in result["findings"]})
+
+        (self.project / "_config.yml").write_text("title: one\ntitle: two\n", encoding="utf-8")
+        invalid = site_tools.site_doctor(self.project)
+        self.assertFalse(invalid["ok"])
+        parse = next(item for item in invalid["findings"] if item["code"] == "UW-SITE-CONFIG-PARSE")
+        self.assertEqual(parse["severity"], "error")
+
+    def test_companion_gate_requires_a_verifiable_provider_receipt(self) -> None:
+        source = self.project / "charts/example.vl.json"
+        output = self.project / "assets/charts/example.svg"
+        data = self.project / "assets/charts/example.csv"
+        extra = self.project / "assets/charts/extra.csv"
+        source.parent.mkdir(parents=True)
+        output.parent.mkdir(parents=True)
+        source.write_text('{"data": {"url": "assets/charts/example.csv"}, "mark": "bar"}\n', encoding="utf-8")
+        output.write_text("<svg/>\n", encoding="utf-8")
+        data.write_text("value\n1\n", encoding="utf-8")
+        extra.write_text("label\na\n", encoding="utf-8")
+        (self.project / ".vegavisuals.yml").write_text(
+            "inputs:\n  - assets/charts/extra.csv\nvisualizations:\n  - source: charts/example.vl.json\n    output: assets/charts/example.svg\n",
+            encoding="utf-8",
+        )
+
+        missing = site_tools.visualization_status(self.project, self.root)
+        self.assertFalse(missing["ok"])
+        self.assertEqual(missing["receipt"]["state"], "missing")
+
+        inputs = site_tools._companion_input_paths(self.project, "vegavisuals")
+        self.assertIn(source, inputs)
+        selected = site_tools.component("vegavisuals")
+        receipt = {
+            "schema_version": 1,
+            "provider": "vegavisuals",
+            "provider_version": selected["version"],
+            "release": selected["release"],
+            "request_sha256": site_tools._companion_request_sha256(self.project, "vegavisuals", inputs),
+            "ok": True,
+            "inputs": [{"path": "assets/charts/extra.csv", "sha256": site_tools._source_hash(extra.read_bytes())}],
+            "artifacts": [{"path": "assets/charts/example.svg", "sha256": site_tools._source_hash(output.read_bytes())}],
+        }
+        receipt_path = self.project / ".unaltraweb/receipts/vegavisuals.json"
+        receipt_path.parent.mkdir(parents=True)
+        receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+        omitted = site_tools.visualization_status(self.project, self.root)
+        self.assertFalse(omitted["ok"])
+        self.assertEqual(omitted["receipt"]["state"], "mismatch")
+        receipt["inputs"].append({"path": "assets/charts/example.csv", "sha256": site_tools._source_hash(data.read_bytes())})
+        receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+        self.assertTrue(site_tools.visualization_status(self.project, self.root)["ok"])
+
+        data.write_text("value\n2\n", encoding="utf-8")
+        stale_data = site_tools.visualization_status(self.project, self.root)
+        self.assertFalse(stale_data["ok"])
+        self.assertEqual(stale_data["receipt"]["state"], "invalid")
+        data.write_text("value\n1\n", encoding="utf-8")
+
+        source.write_text('{"mark": "line"}\n', encoding="utf-8")
+        stale = site_tools.visualization_status(self.project, self.root)
+        self.assertFalse(stale["ok"])
+        self.assertEqual(stale["receipt"]["state"], "mismatch")
+        with patch("unaltraweb_mcp.site_tools.run_make") as run_make:
+            blocked = site_tools.build_site(self.project, self.root)
+        self.assertFalse(blocked["ok"])
+        run_make.assert_not_called()
+
+    def test_vegavisuals_dependency_discovery_rejects_unverifiable_urls_and_deep_specs(self) -> None:
+        source = self.project / "assets/charts/unsafe.vl.json"
+        source.parent.mkdir(parents=True)
+        (self.project / ".vegavisuals.yml").write_text(
+            "visualizations:\n  - source: assets/charts/unsafe.vl.json\n    output: assets/charts/unsafe.svg\n",
+            encoding="utf-8",
+        )
+        cases = {
+            "remote": {"data": {"url": "https://example.org/data.csv"}, "mark": "bar"},
+            "dynamic": {"data": {"url": {"signal": "dataset"}}, "mark": "bar"},
+            "escaping": {"data": {"url": "../outside.csv"}, "mark": "bar"},
+        }
+        for name, specification in cases.items():
+            with self.subTest(name=name):
+                source.write_text(json.dumps(specification), encoding="utf-8")
+                status = site_tools.visualization_status(self.project, self.root)
+                self.assertFalse(status["ok"])
+                self.assertEqual(status["receipt"]["state"], "invalid")
+
+        specification: dict[str, object] = {"data": {"url": "assets/charts/data.csv"}}
+        for _ in range(site_tools.COMPANION_JSON_MAX_DEPTH + 1):
+            specification = {"layer": [specification]}
+        source.write_text(json.dumps(specification), encoding="utf-8")
+        deep = site_tools.visualization_status(self.project, self.root)
+        self.assertFalse(deep["ok"])
+        self.assertIn("inspection limit", deep["receipt"]["error"])
+
+    def test_site_check_requires_fresh_diagrams_and_exact_diavisuals_receipt(self) -> None:
+        source = self.project / "assets/diagrams/flow.mmd"
+        output = Path(str(source) + ".svg")
+        source.parent.mkdir(parents=True)
+        source.write_text("flowchart LR\n  A --> B\n", encoding="utf-8")
+        output.write_text("<svg/>\n", encoding="utf-8")
+
+        with patch("unaltraweb_mcp.site_tools.manual_computation_status", return_value={"ok": True}), patch(
+            "unaltraweb_mcp.site_tools.web_capture_status", return_value={"ok": True}
+        ):
+            missing = site_tools.site_check(self.project, self.root)
+        self.assertFalse(missing["ok"])
+        self.assertFalse(missing["diagrams"]["ok"])
+        self.assertEqual(missing["diagrams"]["receipt"]["state"], "missing")
+
+        sources = site_tools._companion_input_paths(self.project, "diavisuals")
+        selected = site_tools.component("diavisuals")
+        receipt = {
+            "schema_version": 1,
+            "provider": "diavisuals",
+            "provider_version": selected["version"],
+            "release": selected["release"],
+            "request_sha256": site_tools._companion_request_sha256(self.project, "diavisuals", sources),
+            "ok": True,
+            "inputs": [],
+            "artifacts": [{"path": "assets/diagrams/flow.mmd.svg", "sha256": site_tools._source_hash(output.read_bytes())}],
+        }
+        receipt_path = self.project / ".unaltraweb/receipts/diavisuals.json"
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+        with patch("unaltraweb_mcp.site_tools.manual_computation_status", return_value={"ok": True}), patch(
+            "unaltraweb_mcp.site_tools.web_capture_status", return_value={"ok": True}
+        ):
+            verified = site_tools.site_check(self.project, self.root)
+        self.assertTrue(verified["ok"])
+        self.assertTrue(verified["diagrams"]["ok"])
+
+        output_mtime = output.stat().st_mtime_ns
+        os.utime(source, ns=(output_mtime + 1_000_000, output_mtime + 1_000_000))
+        with patch("unaltraweb_mcp.site_tools.manual_computation_status", return_value={"ok": True}), patch(
+            "unaltraweb_mcp.site_tools.web_capture_status", return_value={"ok": True}
+        ):
+            stale = site_tools.site_check(self.project, self.root)
+        self.assertFalse(stale["ok"])
+        self.assertTrue(stale["diagrams"]["receipt"]["ok"])
+        self.assertEqual(stale["diagrams"]["sources"][0]["state"], "stale")
+        source_mtime = source.stat().st_mtime_ns
+        os.utime(output, ns=(source_mtime + 1_000_000, source_mtime + 1_000_000))
+
+        receipt["inputs"] = [{"path": "assets/diagrams/flow.mmd", "sha256": site_tools._source_hash(source.read_bytes())}]
+        receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+        with patch("unaltraweb_mcp.site_tools.manual_computation_status", return_value={"ok": True}), patch(
+            "unaltraweb_mcp.site_tools.web_capture_status", return_value={"ok": True}
+        ):
+            extra_input = site_tools.site_check(self.project, self.root)
+        self.assertFalse(extra_input["ok"])
+        self.assertEqual(extra_input["diagrams"]["receipt"]["state"], "mismatch")
+
+    def test_html_audit_covers_local_quality_without_fetching_external_links(self) -> None:
+        site = self.project / "_site"
+        (site / "about").mkdir(parents=True)
+        (site / "assets").mkdir()
+        (site / "assets/app.js").write_text("", encoding="utf-8")
+        (site / "index.html").write_text(
+            '<!doctype html><html lang="en"><head><title>Home</title><script src="/assets/app.js"></script></head>'
+            '<body><a href="/about/#team">About</a><a href="https://example.com/x">External</a>'
+            '<img src="/assets/app.js" alt=""></body></html>',
+            encoding="utf-8",
+        )
+        (site / "about/index.html").write_text(
+            '<!doctype html><html lang="en"><head><title>About</title></head><body><h1 id="team">Team</h1></body></html>',
+            encoding="utf-8",
+        )
+
+        clean = site_tools.html_audit(self.project)
+        self.assertTrue(clean["ok"], clean["findings"])
+        self.assertEqual(clean["external_fetches"], 0)
+        self.assertEqual(clean["external_links"][0]["url"], "https://example.com/x")
+
+        (site / "index.html").write_text(
+            '<html><head><title></title></head><body><div id="same"></div><div id="same"></div>'
+            '<img src="/missing.png"><a href="/about/#missing">Bad</a>{{ unresolved }}</body></html>',
+            encoding="utf-8",
+        )
+        broken = site_tools.html_audit(self.project)
+        codes = {finding["code"] for finding in broken["findings"]}
+        self.assertFalse(broken["ok"])
+        self.assertTrue({"UW-HTML-DUPLICATE-ID", "UW-HTML-UNRESOLVED-LIQUID", "UW-HTML-IMG-ALT", "UW-HTML-TITLE", "UW-HTML-LANG", "UW-HTML-INTERNAL-TARGET", "UW-HTML-FRAGMENT"}.issubset(codes))
+        doctor = site_tools.site_doctor(self.project)
+        self.assertFalse(doctor["ok"])
+        self.assertIn("UW-SITE-HTML-AUDIT", {finding["code"] for finding in doctor["findings"]})
+
+    def test_html_audit_and_doctor_fail_explicitly_for_missing_or_unknown_required_state(self) -> None:
+        missing = site_tools.html_audit(self.project)
+        self.assertFalse(missing["ok"])
+        self.assertEqual(missing["findings"][0]["code"], "UW-HTML-SITE-MISSING")
+
+        source = self.project / "_chapters/example.py"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text("print('example')\n", encoding="utf-8")
+        doctor = site_tools.site_doctor(self.project)
+        self.assertFalse(doctor["ok"])
+        freshness = next(finding for finding in doctor["findings"] if finding["code"] == "UW-SITE-COMPUTATIONS-FRESHNESS")
+        self.assertEqual(freshness["severity"], "error")
+
+    def test_bounded_process_runner_times_out_process_group_and_caps_output(self) -> None:
+        timed = run_process(
+            [sys.executable, "-c", "import time; time.sleep(5)"],
+            timeout_seconds=0.1,
+        )
+        self.assertTrue(timed.timed_out)
+        self.assertEqual(timed.returncode, 124)
+
+        output = run_process(
+            [sys.executable, "-c", "import sys; sys.stdout.write('x' * 10000); sys.stderr.write('y' * 10000)"],
+            timeout_seconds=2,
+            output_limit=128,
+        )
+        self.assertEqual(output.returncode, 0)
+        self.assertEqual(len(output.stdout.encode()), 128)
+        self.assertEqual(len(output.stderr.encode()), 128)
+        self.assertTrue(output.stdout_truncated)
+        self.assertTrue(output.stderr_truncated)
+
+    def test_timed_out_worker_cleanup_is_scoped_to_invocation_labels(self) -> None:
+        timed_out = site_tools.ProcessResult(
+            args=["make"], returncode=124, stdout="", stderr="timeout", timed_out=True,
+            stdout_truncated=False, stderr_truncated=False,
+        )
+        listed = site_tools.ProcessResult(
+            args=["docker"], returncode=0, stdout="a" * 64 + "\n", stderr="", timed_out=False,
+            stdout_truncated=False, stderr_truncated=False,
+        )
+        removed = site_tools.ProcessResult(
+            args=["docker"], returncode=0, stdout="", stderr="", timed_out=False,
+            stdout_truncated=False, stderr_truncated=False,
+        )
+        with patch("unaltraweb_mcp.site_tools.run_process", side_effect=[timed_out, listed, removed]) as run:
+            result = site_tools.run_factory_make(
+                self.root / "factory",
+                self.project,
+                "manual-compute-render",
+                timeout_seconds=0.1,
+            )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["worker_cleanup"]["removed"], ["a" * 64])
+        make_env = run.call_args_list[0].kwargs["env"]
+        self.assertEqual(make_env["UNALTRAWEB_WORKER_ROLE"], "computation")
+        list_command = run.call_args_list[1].args[0]
+        self.assertEqual(list_command[:3], ["docker", "ps", "-aq"])
+        for label in [
+            site_tools.WORKER_FACTORY_LABEL,
+            site_tools.WORKER_ROLE_LABEL,
+            site_tools.WORKER_PROJECT_LABEL,
+            site_tools.WORKER_TOKEN_LABEL,
+        ]:
+            self.assertTrue(any(label in value for value in list_command))
+        self.assertEqual(run.call_args_list[2].args[0], ["docker", "rm", "-f", "a" * 64])
+
+    def test_http_check_uses_only_owned_preview_origin_and_rejects_hostile_scope(self) -> None:
+        _, project_id, _ = site_tools._preview_identity(self.project)
+        info = {
+            "Config": {"Labels": {
+                site_tools.PREVIEW_FACTORY_LABEL: "unaltraweb",
+                site_tools.PREVIEW_ROLE_LABEL: "preview",
+                site_tools.PREVIEW_PROJECT_LABEL: project_id,
+                site_tools.PREVIEW_PORT_LABEL: "4000",
+                site_tools.PREVIEW_PROFILE_LABEL: "",
+                site_tools.PREVIEW_PATH_LABEL: "/base/en/",
+            }},
+            "State": {"Running": True, "Status": "running", "ExitCode": 0},
+            "NetworkSettings": {"Networks": {"bridge": {"IPAddress": "172.17.0.9"}}},
+        }
+        with patch("unaltraweb_mcp.site_tools._preview_inspect", return_value=info), patch(
+            "unaltraweb_mcp.site_tools._http_probe",
+            return_value={"origin": "http://172.17.0.9:4000", "ok": True, "checks": [], "redirects_followed": 0},
+        ) as probe:
+            result = site_tools.http_check(self.project, paths=["/base/en/", "/assets/app.css"], timeout_seconds=1)
+        self.assertTrue(result["owned"])
+        probe.assert_called_once_with(
+            "http://172.17.0.9:4000",
+            ["/base/en/", "/assets/app.css"],
+            timeout_seconds=1,
+        )
+
+        for hostile in ["https://example.com/", "//example.com/x", "/../secret", "/%2e%2e/secret", "/safe#fragment"]:
+            with self.subTest(path=hostile), self.assertRaises(ValueError):
+                site_tools.http_check(self.project, paths=[hostile])
+        with self.assertRaises(ValueError):
+            site_tools.http_check(self.project, paths=[f"/{index}" for index in range(21)])
+        with self.assertRaises(ValueError):
+            site_tools.http_check(self.project, paths=["/"], timeout_seconds=10)
+
+    def test_private_http_probe_disables_proxies_and_bounds_response_reads(self) -> None:
+        class Response:
+            status = 200
+            reason = "OK"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self, size):
+                self.requested = size
+                return b"x" * size
+
+        response = Response()
+
+        class Opener:
+            def open(self, url, timeout):
+                self.url = url
+                self.timeout = timeout
+                return response
+
+        opener = Opener()
+        with patch("unaltraweb_mcp.site_tools.urllib.request.build_opener", return_value=opener) as build_opener:
+            result = site_tools._http_probe("http://127.0.0.1:4000", ["/health"], timeout_seconds=1)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(response.requested, site_tools.HTTP_RESPONSE_MAX_BYTES + 1)
+        self.assertTrue(result["checks"][0]["response_truncated"])
+        self.assertEqual(build_opener.call_args.args[0].proxies, {})
+
+    @patch("unaltraweb_mcp.site_tools.run_make", return_value={"ok": True, "returncode": 0, "stdout": "", "stderr": ""})
+    def test_build_site_includes_html_audit_after_success(self, _run_make) -> None:
+        site = self.project / "_site"
+        site.mkdir()
+        (site / "index.html").write_text(
+            '<!doctype html><html lang="en"><head><title>Built</title></head><body></body></html>',
+            encoding="utf-8",
+        )
+
+        result = site_tools.build_site(self.project, Path("/opt/unaltraweb"))
+
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["html_audit"]["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_workflows.py
+++ b/test/test_workflows.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts.validate_workflows import load_workflow, validate_workflows
+
+
+class WorkflowTests(unittest.TestCase):
+    def test_repository_workflows_satisfy_static_policy(self) -> None:
+        self.assertEqual(validate_workflows(), [])
+
+    def test_loader_preserves_on_and_rejects_duplicate_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "workflow.yml"
+            path.write_text("on:\n  push:\njobs: {}\n", encoding="utf-8")
+            self.assertIn("on", load_workflow(path))
+            path.write_text("name: first\nname: second\n", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "duplicate YAML key"):
+                load_workflow(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unaltraweb.gemspec
+++ b/unaltraweb.gemspec
@@ -12,18 +12,19 @@ Gem::Specification.new do |spec|
   spec.summary = "Reusable Jekyll core for academic and research websites."
   spec.homepage = "https://github.com/dosquartsdedocs/unaltraweb"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 
   repo_root = File.expand_path(__dir__)
   tracked_files = `git -c safe.directory=#{repo_root.shellescape} ls-files -z`.split("\x0")
   discovered_files = Dir.chdir(repo_root) do
-    Dir.glob("{_includes,_layouts,_sass,_plugins,_scripts,assets,lib,scripts,docs}/**/*", File::FNM_DOTMATCH).reject do |file|
+    (Dir.glob("{_includes,_layouts,_sass,_plugins,_scripts,assets,lib,scripts,docs}/**/*", File::FNM_DOTMATCH) +
+      ["src/unaltraweb_mcp/component-contract.json", "src/unaltraweb_mcp/component-contract.schema.json"]).reject do |file|
       File.directory?(file)
     end
   end
   spec.files = (tracked_files + discovered_files).uniq.select do |file|
     !file.match?(%r{(^|/)__pycache__/|\.pyc\z}) &&
-      (["_config.yml", "Makefile", "requirements.txt"].include?(file) ||
+      (["_config.yml", "Makefile", "requirements.txt", "src/unaltraweb_mcp/component-contract.json", "src/unaltraweb_mcp/component-contract.schema.json"].include?(file) ||
        file.match?(%r{\A(_includes|_layouts|_sass|_plugins|_scripts|assets|lib|scripts)/}) ||
        file.match?(%r{\A(README|LICENSE|docs)/}))
   end


### PR DESCRIPTION
## Summary
- add versioned component BOM, distribution doctor, safe source/scaffold management, HTML audit, and companion receipt gates
- harden project-scoped MCP lifecycle, process/HTTP confinement, and factory-owned packaging
- add PR CI, CodeQL automation, strict image publication preflights, and non-publishing package preparation

## Validation
- 218 Python tests
- make distribution-check, workflow-check, wheel-check, and gem-check
- make mcp-check, mcp-smoke, and docs-build
- ContExt client-config/build dry-runs against the real companion manifests

## Release state
The structural gate passes. The strict release gate intentionally remains blocked until reviewed diavisuals and vegavisuals v0.3.1 releases exist. This PR does not tag or publish artifacts.