### PR TITLE
Fix Docker workflow runner context

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -225,8 +225,6 @@ jobs:
       contents: read
       packages: read
       attestations: read
-    env:
-      DOCKER_CONFIG: ${{ runner.temp }}/unaltraweb-test-docker
     outputs:
       runtime_digest: ${{ steps.tested.outputs.runtime_digest }}
       mcp_digest: ${{ steps.tested.outputs.mcp_digest }}
@@ -236,6 +234,9 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
+
+      - name: Isolate Docker credentials
+        run: printf 'DOCKER_CONFIG=%s\n' "$RUNNER_TEMP/unaltraweb-test-docker" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR for read-only verification
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3

--- a/scripts/validate_workflows.py
+++ b/scripts/validate_workflows.py
@@ -15,7 +15,10 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_ROOT = ROOT / ".github/workflows"
 FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
-JOB_ENV_RUNNER_CONTEXT = re.compile(r"\${{[^}]*\brunner\b")
+JOB_ENV_RUNNER_CONTEXT = re.compile(
+    r"\${{.*?(?<![A-Za-z0-9_.])runner\s*(?:\.|\[).*?}}",
+    re.DOTALL,
+)
 DOCKER_BUILD_COMMAND = re.compile(r"\bdocker\s+(?:build|buildx\s+build|compose\s+build)(?:\s|$)")
 CANDIDATE_EXECUTION_COMMAND = re.compile(
     r"\bdocker\s+(?:(?:container)\s+)?(?:run|create|start|exec)(?:\s|$)"

--- a/scripts/validate_workflows.py
+++ b/scripts/validate_workflows.py
@@ -15,6 +15,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_ROOT = ROOT / ".github/workflows"
 FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+JOB_ENV_RUNNER_CONTEXT = re.compile(r"\${{[^}]*\brunner\b")
 DOCKER_BUILD_COMMAND = re.compile(r"\bdocker\s+(?:build|buildx\s+build|compose\s+build)(?:\s|$)")
 CANDIDATE_EXECUTION_COMMAND = re.compile(
     r"\bdocker\s+(?:(?:container)\s+)?(?:run|create|start|exec)(?:\s|$)"
@@ -141,6 +142,13 @@ def validate_workflows(root: Path = WORKFLOW_ROOT) -> list[str]:
             errors.append(f"{path.name}: invalid YAML: {exc}")
 
     for name, workflow in workflows.items():
+        for job_name, job in workflow.get("jobs", {}).items():
+            if not isinstance(job, dict) or not isinstance(job.get("env", {}), dict):
+                continue
+            for value in job.get("env", {}).values():
+                if isinstance(value, str) and JOB_ENV_RUNNER_CONTEXT.search(value):
+                    errors.append(f"{name}:{job_name}: job-level env cannot use the runner context")
+
         for job_name, step in _steps(workflow):
             uses = step.get("uses")
             if not isinstance(uses, str) or uses.startswith("./"):
@@ -549,6 +557,7 @@ def validate_workflows(root: Path = WORKFLOW_ROOT) -> list[str]:
     test_step_names = [str(step.get("name")) for step in test_steps if step.get("name")]
     expected_test_step_names = [
         "Checkout",
+        "Isolate Docker credentials",
         "Log in to GHCR for read-only verification",
         "Verify signed provenance and exact candidate revisions",
         "Remove GHCR credentials before candidate execution",
@@ -643,15 +652,20 @@ def validate_workflows(root: Path = WORKFLOW_ROOT) -> list[str]:
     ):
         errors.append("docker-image.yml:test-candidates: GHCR login must use only the read-scoped repository token")
 
+    isolation = _named_step(docker_test, "Isolate Docker credentials")
+    isolation_position = test_step_positions.get("Isolate Docker credentials", -1)
+    isolation_text = str(isolation.get("run", ""))
     login_position = test_step_positions.get("Log in to GHCR for read-only verification", -1)
     verification_position = test_step_positions.get("Verify signed provenance and exact candidate revisions", -1)
     logout = _named_step(docker_test, "Remove GHCR credentials before candidate execution")
     logout_position = test_step_positions.get("Remove GHCR credentials before candidate execution", -1)
     logout_text = str(logout.get("run", ""))
     if (
-        docker_test.get("env") != {"DOCKER_CONFIG": "${{ runner.temp }}/unaltraweb-test-docker"}
+        docker_test.get("env") not in (None, {})
         or first_exact_test is None
-        or not (0 <= login_position < verification_position < logout_position < first_exact_test)
+        or not (0 <= isolation_position < login_position < verification_position < logout_position < first_exact_test)
+        or isolation_text.strip()
+        != 'printf \'DOCKER_CONFIG=%s\\n\' "$RUNNER_TEMP/unaltraweb-test-docker" >> "$GITHUB_ENV"'
         or not all(
             marker in logout_text
             for marker in [

--- a/test/test_workflows.py
+++ b/test/test_workflows.py
@@ -214,6 +214,28 @@ class WorkflowTests(unittest.TestCase):
 
         self.assertTrue(any("GHCR credentials must be destroyed before candidate execution" in error for error in errors))
 
+    def test_core_docker_policy_rejects_runner_context_in_job_environment(self) -> None:
+        errors = self.docker_mutation_errors(
+            [
+                (
+                    "  test-candidates:\n"
+                    "    if: github.ref_type == 'branch'\n"
+                    "    needs: build-candidates\n"
+                    "    runs-on: ubuntu-latest\n"
+                    "    timeout-minutes: 120\n",
+                    "  test-candidates:\n"
+                    "    if: github.ref_type == 'branch'\n"
+                    "    needs: build-candidates\n"
+                    "    runs-on: ubuntu-latest\n"
+                    "    timeout-minutes: 120\n"
+                    "    env:\n"
+                    "      DOCKER_CONFIG: ${{ runner.temp }}/unaltraweb-test-docker\n",
+                )
+            ]
+        )
+
+        self.assertTrue(any("job-level env cannot use the runner context" in error for error in errors))
+
     def test_core_docker_policy_rejects_github_token_in_candidate_execution(self) -> None:
         errors = self.docker_mutation_errors(
             [

--- a/test/test_workflows.py
+++ b/test/test_workflows.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from scripts.validate_workflows import load_workflow, validate_workflows
+from scripts.validate_workflows import JOB_ENV_RUNNER_CONTEXT, load_workflow, validate_workflows
 
 
 class WorkflowTests(unittest.TestCase):
@@ -27,6 +27,12 @@ class WorkflowTests(unittest.TestCase):
             path.write_text("name: first\nname: second\n", encoding="utf-8")
             with self.assertRaisesRegex(ValueError, "duplicate YAML key"):
                 load_workflow(path)
+
+    def test_job_environment_runner_context_pattern_uses_only_the_context_root(self) -> None:
+        self.assertIsNotNone(JOB_ENV_RUNNER_CONTEXT.search("${{ runner.temp }}/docker"))
+        self.assertIsNotNone(JOB_ENV_RUNNER_CONTEXT.search("${{ format('{0}', runner['temp']) }}"))
+        self.assertIsNone(JOB_ENV_RUNNER_CONTEXT.search("${{ vars.runner }}"))
+        self.assertIsNone(JOB_ENV_RUNNER_CONTEXT.search("${{ inputs.runner }}"))
 
     def copied_repository(self, root: Path) -> Path:
         workflows = root / ".github/workflows"


### PR DESCRIPTION
## Summary

- initialize the isolated Docker configuration at step runtime through `RUNNER_TEMP` and `GITHUB_ENV`
- reject the unavailable `runner` context in job-level environments
- add regression coverage for the exact GitHub workflow parser failure

## Validation

- `python3 scripts/validate_workflows.py`
- workflow tests: 32 passed
- full Python suite: 383 tests, 12 skipped
- `git diff --check`

Fixes the invalid workflow error observed in run 33847850206; no image was built or published by that run.