### PR TITLE
Keep ContExt on the reviewed MCP release image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ override PROJECT := $${MCP_CONSUMER_WORKSPACE:?MCP_CONSUMER_WORKSPACE is require
 override PROJECT_ROOT := $(PROJECT)
 MCP_RUNTIME_IMAGE ?= ghcr.io/dosquartsdedocs/unaltraweb:0.3.0
 MCP_IMAGE ?= ghcr.io/dosquartsdedocs/unaltraweb-mcp:0.3.0
+MCP_RELEASE_IMAGE ?= ghcr.io/dosquartsdedocs/unaltraweb-mcp@sha256:f3ab5542e6ece56487d4b8238a5e7abd89f36a0b8d87bf7bab19645e3ced1e58
 MCP_DOCKER_BUILD_NETWORK ?= default
 INIT_SITE_PROFILE ?= unaltreselfie
 NEW_WEB_PROFILE ?= unaltreselfie
@@ -107,18 +108,22 @@ gem-check: ## Build the gem and verify its package-owned contract files
 reproducible-site-check: ## Build the same fixed-epoch Jekyll fixture twice and compare every output
 	@DOCKER_IMAGE="$(DOCKER_IMAGE)" $(PYTHON) scripts/test_reproducible_jekyll_build.py
 
-mcp-runtime-image: ## Build the reusable Jekyll runtime used by the MCP
+mcp-runtime-image mcp-image mcp-check mcp-smoke: MCP_RUNTIME_IMAGE = unaltraweb:dev
+mcp-runtime-image mcp-image mcp-check mcp-smoke: MCP_IMAGE = unaltraweb-mcp:dev
+
+mcp-runtime-image: ## Build the local development Jekyll runtime used by the MCP
 	docker build --network "$(MCP_DOCKER_BUILD_NETWORK)" -t "$(MCP_RUNTIME_IMAGE)" .
 
-mcp-image: mcp-runtime-image ## Build the Dockerized FastMCP control plane
+mcp-image: mcp-runtime-image ## Build the local development FastMCP control plane
 	docker build --network "$(MCP_DOCKER_BUILD_NETWORK)" --build-arg "UNALTRAWEB_RUNTIME_IMAGE=$(MCP_RUNTIME_IMAGE)" -t "$(MCP_IMAGE)" -f Dockerfile.mcp .
 
-mcp-build: mcp-image ## Prepare the Docker images used by MCP sessions, builds, and previews
+mcp-build: ## Prepare the reviewed release image used by MCP sessions, builds, and previews
+	@docker image inspect "$(MCP_RELEASE_IMAGE)" >/dev/null 2>&1 || docker pull "$(MCP_RELEASE_IMAGE)" >/dev/null
 
 mcp-check: mcp-image ## Verify the Dockerized MCP CLI contract
 	docker run --rm --entrypoint unaltraweb-mcp "$(MCP_IMAGE)" version
 
-mcp-smoke: mcp-build ## Build and prove a real MCP stdio connection
+mcp-smoke: mcp-image ## Build and prove a real MCP stdio connection
 	@$(MAKE) --silent --no-print-directory mcp-smoke-prebuilt MCP_IMAGE="$(MCP_IMAGE)"
 
 mcp-smoke-prebuilt: ## Prove a real MCP stdio connection using the selected prebuilt MCP image
@@ -137,7 +142,7 @@ mcp-smoke-prebuilt: ## Prove a real MCP stdio connection using the selected preb
 
 mcp-stdio: ## Serve MCP_CONSUMER_WORKSPACE through the Dockerized stdio MCP
 	@test -n "$${MCP_CONSUMER_WORKSPACE:-}" || { printf '%s\n' 'MCP_CONSUMER_WORKSPACE is required' >&2; exit 2; }
-	@exec "$(CURDIR)/scripts/unaltraweb-mcp-bootstrap.sh" --image "$(MCP_IMAGE)"
+	@exec "$(CURDIR)/scripts/unaltraweb-mcp-bootstrap.sh" --image "$(MCP_RELEASE_IMAGE)"
 
 mcp-down: ## Remove MCP resources owned by MCP_CONSUMER_WORKSPACE or MCP_PROJECT_ID
 	@exec "$(CURDIR)/scripts/unaltraweb-mcp-cleanup.sh"

--- a/test/test_mcp_runtime.py
+++ b/test/test_mcp_runtime.py
@@ -1135,6 +1135,11 @@ class McpRuntimeTests(unittest.TestCase):
         release_prefix = "ghcr.io/dosquartsdedocs/unaltraweb-mcp@sha256:"
         release_digest = release_image.removeprefix(release_prefix)
 
+        self.assertEqual(
+            release_image,
+            "ghcr.io/dosquartsdedocs/unaltraweb-mcp@sha256:"
+            "f3ab5542e6ece56487d4b8238a5e7abd89f36a0b8d87bf7bab19645e3ced1e58",
+        )
         self.assertTrue(release_image.startswith(release_prefix))
         self.assertEqual(len(release_digest), 64)
         self.assertTrue(all(character in "0123456789abcdef" for character in release_digest))

--- a/test/test_mcp_runtime.py
+++ b/test/test_mcp_runtime.py
@@ -1122,6 +1122,96 @@ class McpRuntimeTests(unittest.TestCase):
         self.assertIn("must be inherited", command_line.stderr)
         self.assertFalse(marker.exists())
 
+    def test_mcp_make_targets_separate_release_preparation_from_development_builds(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        makefile = (root / "Makefile").read_text(encoding="utf-8")
+        assignments = {
+            key: value
+            for line in makefile.splitlines()
+            if " ?= " in line
+            for key, value in [line.split(" ?= ", 1)]
+        }
+        release_image = assignments["MCP_RELEASE_IMAGE"]
+        release_prefix = "ghcr.io/dosquartsdedocs/unaltraweb-mcp@sha256:"
+        release_digest = release_image.removeprefix(release_prefix)
+
+        self.assertTrue(release_image.startswith(release_prefix))
+        self.assertEqual(len(release_digest), 64)
+        self.assertTrue(all(character in "0123456789abcdef" for character in release_digest))
+        self.assertNotEqual(release_image, assignments["MCP_IMAGE"])
+        self.assertIn("mcp-smoke: mcp-image", makefile)
+        self.assertIn("mcp-check: mcp-image", makefile)
+        self.assertIn(
+            "mcp-runtime-image mcp-image mcp-check mcp-smoke: MCP_IMAGE = unaltraweb-mcp:dev",
+            makefile,
+        )
+        self.assertIn('--image "$(MCP_RELEASE_IMAGE)"', makefile)
+
+        make_env = os.environ.copy()
+        for variable in ["MCP_RELEASE_IMAGE", "MCP_RUNTIME_IMAGE", "MCP_IMAGE", "DOCKER_INSPECT_STATUS"]:
+            make_env.pop(variable, None)
+
+        def run_make(*arguments: str, env: dict[str, str] = make_env) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                ["make", "--no-print-directory", "-C", str(root), *arguments],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+                check=False,
+            )
+
+        dry_run = run_make("--dry-run", "mcp-image")
+        self.assertEqual(dry_run.returncode, 0, dry_run.stderr)
+        self.assertIn('-t "unaltraweb:dev"', dry_run.stdout)
+        self.assertIn('-t "unaltraweb-mcp:dev"', dry_run.stdout)
+
+        overridden = run_make(
+            "--dry-run", "mcp-image",
+            "MCP_RUNTIME_IMAGE=example/runtime:test", "MCP_IMAGE=example/mcp:test",
+        )
+        self.assertEqual(overridden.returncode, 0, overridden.stderr)
+        self.assertIn('-t "example/runtime:test"', overridden.stdout)
+        self.assertIn('-t "example/mcp:test"', overridden.stdout)
+
+        stdio = run_make("--dry-run", "mcp-stdio", env={**make_env, "MCP_CONSUMER_WORKSPACE": str(self.project)})
+        self.assertEqual(stdio.returncode, 0, stdio.stderr)
+        self.assertIn(f'--image "{release_image}"', stdio.stdout)
+
+        fake_bin = self.project / "release-image-bin"
+        fake_bin.mkdir()
+        calls = self.project / "release-image-docker-calls"
+        docker = fake_bin / "docker"
+        docker.write_text(
+            "#!/bin/sh\n"
+            "printf '%s\\n' \"$*\" >> \"$CAPTURE\"\n"
+            "if test \"$1\" = image && test \"$2\" = inspect; then\n"
+            "  exit \"${DOCKER_INSPECT_STATUS:-1}\"\n"
+            "fi\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        docker.chmod(0o755)
+        env = make_env.copy()
+        env.update({"PATH": f"{fake_bin}:{env['PATH']}", "CAPTURE": str(calls)})
+
+        completed = run_make("--silent", "mcp-build", env=env)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        recorded_calls = calls.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(
+            recorded_calls,
+            [f"image inspect {release_image}", f"pull {release_image}"],
+        )
+        self.assertTrue(all(not call.startswith("build ") for call in recorded_calls))
+
+        calls.unlink()
+        env["DOCKER_INSPECT_STATUS"] = "0"
+        completed = run_make("--silent", "mcp-build", env=env)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(calls.read_text(encoding="utf-8").splitlines(), [f"image inspect {release_image}"])
+
     def test_visualization_status_requires_provider_receipt_for_configured_project(self) -> None:
         (self.project / ".vegavisuals.yml").write_text("visualizations: []\n", encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- make `mcp-build` prepare the immutable public MCP image recorded for the completed release
- make `mcp-stdio` launch that digest while source builds/checks/smoke use local `:dev` defaults
- preserve explicit command-line image overrides and test inspect/pull behavior without real registry mutation

## Release lifecycle
`MCP_RELEASE_IMAGE` is a post-release pin. Candidate source and receipt-only commits retain the previous completed release; a separate post-release change advances the pin after the next receipt exists, avoiding a self-digest cycle.

## Verification
- `PYTHONPATH=src python3 -m unittest discover -s test -p 'test_*.py'` (407 passed, 12 skipped)\n- `make distribution-check`\n- `make workflow-check`\n- `make mcp-build`\n- `make mcp-check mcp-smoke MCP_RUNTIME_IMAGE=unaltraweb-runtime:issue25 MCP_IMAGE=unaltraweb-mcp:issue25`\n- `git diff --check`\n- independent review: no material findings\n\nNo image/package was published, no tag/release moved, no consumer was deployed, and temporary development images were removed.\n\nCloses #25